### PR TITLE
Mutex node refactor

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -17,7 +17,7 @@ args = ["doc", "--all-features", "--open"]
 # Lint all features.
 [tasks.lint]
 command = "cargo"
-args = ["clippy", "--all-features"]
+args = ["clippy", "--all-features", "--", "-D", "clippy::pedantic", "-D", "clippy::nursery"]
 
 # Run tests under miri.
 # NOTE: must run as: cargo +nightly make miri

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ and also compatible with `no_std`, consider using [spin-rs].
 This crate dos not provide any default features. Features that can be enabled
 are:
 
-### yield
+### `yield`
 
 The `yield` feature requires linking to the standard library, so it is not
 suitable for `no_std` environments. By enabling the `yield` feature, instead
@@ -135,7 +135,7 @@ this feature if your intention is to to actually do optimistic spinning. The
 default implementation calls [`core::hint::spin_loop`], which does in fact
 just simply busy-waits.
 
-### thread_local
+### `thread_local`
 
 The `thread_local` feature provides locking APIs that do not require user-side
 node instantiation, but critical sections must be provided as closures. This

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -38,8 +38,7 @@ fn main() {
 
     // A queue node must be mutably accessible.
     let mut node = MutexNode::new();
-    // Would return `None` if lock was already held.
-    let count = data.try_lock(&mut node).unwrap();
+    let count = data.lock(&mut node);
     assert_eq!(*count, N);
     // lock is unlock here when `count` goes out of scope.
 }

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -35,6 +35,8 @@ fn main() {
             })
         });
     }
+    let _message = rx.recv().unwrap();
 
-    rx.recv().unwrap();
+    let count = data.lock_with(|guard| **guard);
+    assert_eq!(count, N);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,11 +154,12 @@
     all(not(any(feature = "yield", feature = "thread_local")), not(loom), not(test)),
     no_std
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 pub mod raw;
 
 // The `thread_local` feature requires linking with std.
 #[cfg(feature = "thread_local")]
+#[cfg_attr(docsrs, doc(cfg(feature = "thread_local")))]
 pub mod thread_local;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@
 //! This crate dos not provide any default features. Features that can be enabled
 //! are:
 //!
-//! ### yield
+//! ### `yield`
 //!
 //! The `yield` feature requires linking to the standard library, so it is not
 //! suitable for `no_std` environments. By enabling the `yield` feature, instead
@@ -116,7 +116,7 @@
 //! default implementation calls [`core::hint::spin_loop`], which does in fact
 //! just simply busy-waits.
 //!
-//! ### thread_local
+//! ### `thread_local`
 //!
 //! The `thread_local` feature provides locking APIs that do not require user-side
 //! node instantiation, but critical sections must be provided as closures. This

--- a/src/thread_local.rs
+++ b/src/thread_local.rs
@@ -145,6 +145,7 @@ impl<T: ?Sized> Mutex<T> {
         NODE.with(|node| f(&self.0, &mut node.borrow_mut()))
     }
 
+    /// Runs `f` over the inner mutex and the thread local node.
     #[cfg(all(loom, test))]
     fn node_with<F, R>(&self, f: F) -> R
     where

--- a/src/thread_local.rs
+++ b/src/thread_local.rs
@@ -334,7 +334,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
             Some(g) => g.raw.data_with(|data| d.field("data", &data)),
             None => d.field("data", &format_args!("<locked>")),
         });
-        d.field("tail", self.0.tail());
+        d.field("tail", self.0.tail_debug());
         d.finish()
     }
 }


### PR DESCRIPTION
Queue nodes now hold both the next pointer and locked state. The queue is now formed of initialized nodes instead of _maybe initialized_ nodes, which reduces the number of unsafe calls. Removed private locking functions that would operate on raw pointers, which also reduced project's usage of unsafe code.