### PR TITLE
Add barging MCS lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,12 @@ jobs:
         run: rustup toolchain install stable
       - name: Run raw example
         run: cargo run --example raw
+      - name: Run barging example
+        run: cargo run --example barging
       - name: Run thread_local example
         run: cargo run --example thread_local --features thread_local
+      - name: Run lock_api example
+        run: cargo run --example lock_api --features lock_api
 
   linter:
     name: Linter
@@ -81,10 +85,12 @@ jobs:
         run: cargo clippy --features yield
       - name: Lint thread_local
         run: cargo clippy --features thread_local
+      - name: Lint lock_api
+        run: cargo clippy --features lock_api
       - name: Lint loom
         env:
           RUSTFLAGS: ${{ env.LOOM_RUSTFLAGS }}
-        run: cargo clippy --profile test --features thread_local
+        run: cargo clippy --profile test --all-features
 
   miri:
     name: Miri
@@ -98,7 +104,7 @@ jobs:
       - name: Set Rust nightly as default
         run: rustup default nightly
       - name: Miri test
-        run: cargo miri test --features thread_local
+        run: cargo miri test --all-features
 
   loom:
     name: Loom
@@ -111,4 +117,4 @@ jobs:
       - name: Loom test
         env:
           RUSTFLAGS: ${{ env.LOOM_RUSTFLAGS }}
-        run: cargo test --lib --release --features thread_local
+        run: cargo test --lib --release --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ loom = { version = "0.7" }
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[[test]]
+name = "lock_api"
+required-features = ["lock_api", "yield"]
+
 [[example]]
 name = "thread_local"
 required-features = ["thread_local"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[example]]
 name = "thread_local"
 required-features = ["thread_local"]
+
+[[example]]
+name = "lock_api"
+required-features = ["lock_api"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,22 +6,31 @@ spin-lock for mutual exclusion, referred to as MCS lock.
 name = "mcslock"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.60.0"
+# NOTE: Rust 1.65 is required for GATs and let-else statements.
+rust-version = "1.65.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 # documentation = "https://docs.rs/mcslock"
 # homepage = "https://crates.io/mcslock"
 repository = "https://github.com/pedromfedricci/mcslock"
 authors = ["Pedro de Matos Fedricci <pedromfedricci@gmail.com>"]
-categories = ["no-std", "no-std::no-alloc", "concurrency"]
+categories = ["no-std", "concurrency"]
 keywords = ["no_std", "mutex", "spin-lock", "mcs-lock"]
 
 [workspace]
 members = [".", "benches"]
 
 [features]
+# NOTE: Features `yield` and `thread_local` require std.
 yield = []
 thread_local = []
+# NOTE: The `dep:` syntax requires Rust 1.60.
+lock_api = ["dep:lock_api"]
+
+[dependencies.lock_api]
+version = "0.4"
+default-features = false
+optional = true
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.7" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,3 +1,6 @@
+[env]
+CFG_LOOM = "--cfg loom"
+
 # Don't run these tasks for all crates in the workspace.
 [config]
 default_to_workspace = false
@@ -25,19 +28,19 @@ args = ["clippy", "--all-features", "--", "-D", "clippy::pedantic", "-D", "clipp
 toolchain = "nightly"
 install_crate = { rustup_component_name = "miri" }
 command = "cargo"
-args = ["miri", "test", "--features", "thread_local"]
+args = ["miri", "test", "--all-features"]
 
 # Run Loom tests.
 [tasks.loom-test]
 command = "cargo"
-env = { "RUSTFLAGS" = "--cfg loom" }
-args = ["test", "--lib", "--release", "--features", "thread_local"]
+env = { "RUSTFLAGS" = "${CFG_LOOM}" }
+args = ["test", "--lib", "--release", "--all-features"]
 
 # Lint Loom cfg.
 [tasks.loom-lint]
 command = "cargo"
-env = { "RUSTFLAGS" = "--cfg loom" }
-args = ["clippy", "--profile", "test", "--features", "thread_local"]
+env = { "RUSTFLAGS" = "${CFG_LOOM}" }
+args = ["clippy", "--profile", "test", "--all-features", "--", "-D", "clippy::pedantic", "-D", "clippy::nursery"]
 
 # Run busy loop bench.
 [tasks.bench-busy]

--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ implementation handles the queue's nodes transparently, by storing them in
 the thread local storage of the waiting threads. These locking implementations
 will panic if recursively acquired. Not `no_std` compatible.
 
+### lock_api
+
+This feature implements the [`RawMutex`] trait from the [lock_api]
+crate for `mcslock::Mutex`. Aliases are provided by the `lock_api` module.
+This features is `no_std` compatible.
+
 ## Related projects
 
 These projects provide MCS lock implementations with slightly different APIs,

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ And a simpler correctness proof of the MCS lock was proposed by [Johnson and Har
 
 ## Use cases
 
-[Spinlocks are usually not what you want]. The majority of use cases are well
-covered by OS-based mutexes like [`std::sync::Mutex`] or [`parking_lot::Mutex`].
-These implementations will notify the system that the waiting thread should
-be parked, freeing the processor to work on something else.
+It is noteworthy to mention that [spinlocks are usually not what you want]. The
+majority of use cases are well covered by OS-based mutexes like
+[`std::sync::Mutex`] or [`parking_lot::Mutex`]. These implementations will notify
+the system that the waiting thread should be parked, freeing the processor to
+work on something else.
 
 Spinlocks are only efficient in very few circunstances where the overhead
 of context switching or process rescheduling are greater than busy waiting
@@ -162,11 +163,11 @@ implementation handles the queue's nodes transparently, by storing them in
 the thread local storage of the waiting threads. These locking implementations
 will panic if recursively acquired. Not `no_std` compatible.
 
-### lock_api
+### `lock_api`
 
-This feature implements the [`RawMutex`] trait from the [lock_api]
-crate for `mcslock::Mutex`. Aliases are provided by the `lock_api` module.
-This features is `no_std` compatible.
+This feature implements the `RawMutex` trait from the [lock_api] crate for
+`barging::Mutex`. Aliases are provided by the `lock_api` module. This feature
+is `no_std` compatible.
 
 ## Related projects
 
@@ -205,7 +206,7 @@ each of your dependencies, including this one.
 [spin-rs]: https://docs.rs/spin/latest/spin
 [lock_api]: https://docs.rs/lock_api/latest/lock_api
 [Linux kernel mutexes]: https://www.kernel.org/doc/html/latest/locking/mutex-design.html
-[Spinlocks are usually not what you want]: https://matklad.github.io/2020/01/02/spinlocks-considered-harmful.html
+[spinlocks are usually not what you want]: https://matklad.github.io/2020/01/02/spinlocks-considered-harmful.html
 [Mellor-Crummey and Scott]: https://www.cs.rochester.edu/~scott/papers/1991_TOCS_synch.pdf
 [Johnson and Harathi]: https://web.archive.org/web/20140411142823/http://www.cise.ufl.edu/tr/DOC/REP-1992-71.pdf
 [cargo-crev]: https://github.com/crev-dev/cargo-crev

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cargo doc --all-features --open
 This implementation will have non-waiting threads race for the lock against
 the front of the waiting queue thread, which means this it is an unfair lock.
 This implementation is suitable for `no_std` environments, and the locking
-APIs are compatible with the `lock_api` crate. See `barging` and `lock_api`
+APIs are compatible with the [lock_api] crate. See `barging` and `lock_api`
 modules for more information.
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ will panic if recursively acquired. Not `no_std` compatible.
 
 ### lock_api
 
-This feature implements the `RawMutex` trait from the [lock_api] crate for
+This feature implements the [`RawMutex`] trait from the [lock_api] crate for
 `barging::Mutex`. Aliases are provided by the `lock_api` module. This feature
 is `no_std` compatible.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Include the following under the `[dependencies]` section in your `Cargo.toml` fi
 # Cargo.toml
 
 [dependencies]
-# Avaliable features: `yield`, `thread_local`.
+# Avaliable features: `yield`, `thread_local` and `lock_api`.
 mcslock = { version = "0.1", git = "https://github.com/pedromfedricci/mcslock" }
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ These projects provide MCS lock implementations with slightly different APIs,
 implementation details or compiler requirements, you can check their
 repositories:
 
-- `mcs-rs`: <https://github.com/gereeter/mcs-rs>
-- `libmcs`: <https://github.com/topecongiro/libmcs>
+- mcs-rs: <https://github.com/gereeter/mcs-rs>
+- libmcs: <https://github.com/topecongiro/libmcs>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ fn main() {
 This crate dos not provide any default features. Features that can be enabled
 are:
 
-### `yield`
+### yield
 
 The `yield` feature requires linking to the standard library, so it is not
 suitable for `no_std` environments. By enabling the `yield` feature, instead
@@ -155,7 +155,7 @@ this feature if your intention is to to actually do optimistic spinning. The
 default implementation calls [`core::hint::spin_loop`], which does in fact
 just simply busy-waits.
 
-### `thread_local`
+### thread_local
 
 The `thread_local` feature provides locking APIs that do not require user-side
 node instantiation, but critical sections must be provided as closures. This
@@ -163,7 +163,7 @@ implementation handles the queue's nodes transparently, by storing them in
 the thread local storage of the waiting threads. These locking implementations
 will panic if recursively acquired. Not `no_std` compatible.
 
-### `lock_api`
+### lock_api
 
 This feature implements the `RawMutex` trait from the [lock_api] crate for
 `barging::Mutex`. Aliases are provided by the `lock_api` module. This feature

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ fn main() {
 ## Thread local MCS lock
 
 This implementation also operates under FIFO. The locking APIs provided
-by this module do not require user-side node instantiation, critical
+by this module do not require user-side node allocation, critical
 sections must be provided as closures and at most one lock can be held at
 any time within a thread. It is not `no_std` compatible and can be enabled
 through the `thread_local` feature. See `thread_local` module for more
@@ -158,7 +158,7 @@ just simply busy-waits.
 ### thread_local
 
 The `thread_local` feature provides locking APIs that do not require user-side
-node instantiation, but critical sections must be provided as closures. This
+node allocation, but critical sections must be provided as closures. This
 implementation handles the queue's nodes transparently, by storing them in
 the thread local storage of the waiting threads. These locking implementations
 will panic if recursively acquired. Not `no_std` compatible.

--- a/examples/barging.rs
+++ b/examples/barging.rs
@@ -2,7 +2,7 @@ use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
 
-use mcslock::spins::Mutex;
+use mcslock::barging::spins::Mutex;
 
 fn main() {
     const N: usize = 10;

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -2,12 +2,11 @@ use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
 
-// Requires that the `thread_local` feature is enabled.
-use mcslock::thread_local::spins::Mutex;
-
-const N: usize = 10;
+use mcslock::spins::Mutex;
 
 fn main() {
+    const N: usize = 10;
+
     // Spawn a few threads to increment a shared variable (non-atomically), and
     // let the main thread know once all increments are done.
     //
@@ -25,19 +24,17 @@ fn main() {
             //
             // We unwrap() the return value to assert that we are not expecting
             // threads to ever fail while holding the lock.
-            //
-            // Data is exclusively accessed by the guard argument.
-            data.lock_with(|mut data| {
-                *data += 1;
-                if *data == N {
-                    tx.send(()).unwrap();
-                }
-                // the lock is unlocked here when `data` goes out of scope.
-            })
+            let mut data = data.lock();
+            *data += 1;
+            if *data == N {
+                tx.send(()).unwrap();
+            }
+            // the lock is unlocked here when `data` goes out of scope.
         });
     }
-    let _message = rx.recv().unwrap();
+    let _message = rx.recv();
 
-    let count = data.lock_with(|guard| *guard);
-    assert_eq!(count, N);
+    let count = data.lock();
+    assert_eq!(*count, N);
+    // lock is unlock here when `count` goes out of scope.
 }

--- a/src/barging/mod.rs
+++ b/src/barging/mod.rs
@@ -1,12 +1,12 @@
-//! A barging MCS lock implementation that is compliant with the `lock_api` crate.
+//! A barging MCS lock implementation that is compliant with the [lock_api] crate.
 //!
 //! This implementation will have non-waiting threads race for the lock against
 //! the front of the waiting queue thread. If the front of the queue thread
 //! looses the race, it will simply keep spinning, while holding its position
 //! in the queue. By allowing barging instead of forcing FIFO, a higher throughput
 //! can be achieved when the lock is heavily contended. This implementation is
-//! suitable for `no_std` environments, and the locking API is compatible with
-//! the `lock_api` crate (see `lock_api` feature).
+//! suitable for `no_std` environments, and the locking APIs are compatible with
+//! the [lock_api] crate (see `lock_api` feature).
 //!
 //! The lock is hold for as long as its associated RAII guard is in scope. Once
 //! the guard is dropped, the mutex is freed. Mutex guards are returned by
@@ -19,6 +19,7 @@
 //! [`Mutex`] and [`MutexGuard`] associated with one relax strategy. See their
 //! documentation for more information.
 //!
+//! [lock_api]: https://crates.io/crates/lock_api
 //! [`lock`]: Mutex::lock
 //! [`try_lock`]: Mutex::try_lock
 //! [`lock_with`]: Mutex::lock_with

--- a/src/barging/mod.rs
+++ b/src/barging/mod.rs
@@ -1,0 +1,150 @@
+//! A barging MCS lock implementation that is compliant with the `lock_api` crate.
+//!
+//! This implementation will have non-waiting threads race for the lock against
+//! the front of the waiting queue thread. If the front of the queue thread
+//! looses the race, it will simply keep spinning, while holding its position
+//! in the queue. By allowing barging instead of forcing FIFO, a higher throughput
+//! can be achieved when the lock is heavily contended. This implementation is
+//! suitable for `no_std` environments, and the locking API is compatible with
+//! the `lock_api` crate (see `lock_api` feature).
+//!
+//! The lock is hold for as long as its associated RAII guard is in scope. Once
+//! the guard is dropped, the mutex is freed. Mutex guards are returned by
+//! [`lock`] and [`try_lock`]. Guards are also accessible as the closure argument
+//! for [`lock_with`] and [`try_lock_with`] methods.
+//!
+//! The Mutex is generic over the relax strategy. User may choose a strategy
+//! as long as it implements the [`Relax`] trait. There is a number of strategies
+//! provided by the [`relax`] module. Each submodule provides type aliases for
+//! [`Mutex`] and [`MutexGuard`] associated with one relax strategy. See their
+//! documentation for more information.
+//!
+//! [`lock`]: Mutex::lock
+//! [`try_lock`]: Mutex::try_lock
+//! [`lock_with`]: Mutex::lock_with
+//! [`try_lock_with`]: Mutex::try_lock_with
+//! [`relax`]: crate::relax
+//! [`Relax`]: crate::relax::Relax
+
+mod mutex;
+pub use mutex::{Mutex, MutexGuard};
+
+/// A `barging` MCS lock alias that signals the processor that it is running
+/// a busy-wait spin-loop during lock contention.
+pub mod spins {
+    use crate::relax::Spin;
+
+    /// A `barging` MCS lock that implements the [`Spin`] relax strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::barging::spins::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, Spin>;
+
+    /// A `barging` MCS guard that implements the [`Spin`] relax strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Spin>;
+}
+
+/// A `barging` MCS lock alias that yields the current time slice to the
+/// OS scheduler during lock contention.
+#[cfg(any(feature = "yield", loom, test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "yield")))]
+pub mod yields {
+    use crate::relax::Yield;
+
+    /// A `barging` MCS lock that implements the [`Yield`] relax strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::barging::yields::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, Yield>;
+
+    /// A `barging` MCS guard that implements the [`Yield`] relax strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Yield>;
+}
+
+/// A `barging` MCS lock alias that rapidly spins without telling the CPU
+/// to do any power down during lock contention.
+pub mod loops {
+    use crate::relax::Loop;
+
+    /// A `barging` MCS lock that implements the [`Loop`] relax strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::barging::loops::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, Loop>;
+
+    /// A `barging` MCS guard that implements the [`Loop`] relax strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Loop>;
+}
+
+/// A `barging` MCS lock alias that, during lock contention, will perform
+/// exponential backoff while signaling the processor that it is running a
+/// busy-wait spin-loop.
+pub mod spins_backoff {
+    use crate::relax::SpinBackoff;
+
+    /// A `barging` MCS lock that implements the [`SpinBackoff`] relax
+    /// strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::barging::spins_backoff::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, SpinBackoff>;
+
+    /// A `barging` MCS guard that implements the [`SpinBackoff`] relax
+    /// strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, SpinBackoff>;
+}
+
+/// A `barging` MCS lock alias that, during lock contention, will perform
+/// exponential backoff while spinning up to a threshold, then yields back to
+/// the OS scheduler.
+#[cfg(feature = "yield")]
+#[cfg_attr(docsrs, doc(cfg(feature = "yield")))]
+pub mod yields_backoff {
+    use crate::relax::YieldBackoff;
+
+    /// A `barging` MCS lock that implements the [`YieldBackoff`] relax
+    /// strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::barging::yields_backoff::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, YieldBackoff>;
+
+    /// A `barging` MCS guard that implements the [`YieldBackoff`] relax
+    /// strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, YieldBackoff>;
+}

--- a/src/barging/mod.rs
+++ b/src/barging/mod.rs
@@ -43,8 +43,8 @@ pub mod spins {
     /// use mcslock::barging::spins::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, Spin>;
 
@@ -67,8 +67,8 @@ pub mod yields {
     /// use mcslock::barging::yields::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, Yield>;
 
@@ -89,8 +89,8 @@ pub mod loops {
     /// use mcslock::barging::loops::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, Loop>;
 
@@ -113,8 +113,8 @@ pub mod spins_backoff {
     /// use mcslock::barging::spins_backoff::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, SpinBackoff>;
 
@@ -140,8 +140,8 @@ pub mod yields_backoff {
     /// use mcslock::barging::yields_backoff::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, YieldBackoff>;
 

--- a/src/barging/mutex.rs
+++ b/src/barging/mutex.rs
@@ -210,7 +210,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     /// Borrows of the guard or its data cannot escape the given closure.
     ///
     /// ```compile_fail,E0515
-    /// use mcslock::spins::Mutex;
+    /// use mcslock::barging::spins::Mutex;
     ///
     /// let mutex = Mutex::new(1);
     /// let data = mutex.lock_with(|guard| &*guard);
@@ -303,7 +303,7 @@ impl<T: ?Sized, R> Mutex<T, R> {
     /// Borrows of the guard or its data cannot escape the given closure.
     ///
     /// ```compile_fail,E0515
-    /// use mcslock::spins::Mutex;
+    /// use mcslock::barging::spins::Mutex;
     ///
     /// let mutex = Mutex::new(1);
     /// let data = mutex.try_lock_with(|guard| &*guard.unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,11 @@
 //!
 //! ## Use cases
 //!
-//! [Spinlocks are usually not what you want]. The majority of use cases are well
-//! covered by OS-based mutexes like [`std::sync::Mutex`] or [`parking_lot::Mutex`].
-//! These implementations will notify the system that the waiting thread should
-//! be parked, freeing the processor to work on something else.
+//! It is noteworthy to mention that [spinlocks are usually not what you want].
+//! The majority of use cases are well covered by OS-based mutexes like
+//! [`std::sync::Mutex`] or [`parking_lot::Mutex`]. These implementations will
+//! notify the system that the waiting thread should be parked, freeing the
+//! processor to work on something else.
 //!
 //! Spinlocks are only efficient in very few circunstances where the overhead
 //! of context switching or process rescheduling are greater than busy waiting
@@ -145,8 +146,8 @@
 //! ### `lock_api`
 //!
 //! This feature implements the [`RawMutex`] trait from the [lock_api]
-//! crate for [`mcslock::Mutex`]. Aliases are provided by the [`mod@lock_api`]
-//! module. This features is `no_std` compatible.
+//! crate for [`barging::Mutex`]. Aliases are provided by the
+//! [`mod@lock_api`] module. This feature is `no_std` compatible.
 //!
 //! ## Related projects
 //!
@@ -158,11 +159,8 @@
 //! - `libmcs`: <https://github.com/topecongiro/libmcs>
 //!
 //! [`MutexNode`]: raw::MutexNode
-//! [`lock`]: raw::Mutex::lock
-//! [`try_lock`]: raw::Mutex::try_lock
 //! [`std::sync::Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
 //! [`parking_lot::Mutex`]: https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html
-//! [`mcslock::Mutex`]: crate::Mutex
 //! [`RawMutex`]: https://docs.rs/lock_api/latest/lock_api/trait.RawMutex.html
 //! [`RawMutexFair`]: https://docs.rs/lock_api/latest/lock_api/trait.RawMutexFair.html
 //! [`std::thread::yield_now`]: https://doc.rust-lang.org/std/thread/fn.yield_now.html
@@ -170,7 +168,7 @@
 //! [spin-rs]: https://docs.rs/spin/latest/spin
 //! [lock_api]: https://docs.rs/lock_api/latest/lock_api
 //! [Linux kernel mutexes]: https://www.kernel.org/doc/html/latest/locking/mutex-design.html
-//! [Spinlocks are usually not what you want]: https://matklad.github.io/2020/01/02/spinlocks-considered-harmful.html
+//! [spinlocks are usually not what you want]: https://matklad.github.io/2020/01/02/spinlocks-considered-harmful.html
 //! [Mellor-Crummey and Scott]: https://www.cs.rochester.edu/~scott/papers/1991_TOCS_synch.pdf
 //! [Johnson and Harathi]: https://web.archive.org/web/20140411142823/http://www.cise.ufl.edu/tr/DOC/REP-1992-71.pdf
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@
 //! This crate dos not provide any default features. Features that can be enabled
 //! are:
 //!
-//! ### `yield`
+//! ### yield
 //!
 //! The `yield` feature requires linking to the standard library, so it is not
 //! suitable for `no_std` environments. By enabling the `yield` feature, instead
@@ -135,7 +135,7 @@
 //! default implementation calls [`core::hint::spin_loop`], which does in fact
 //! just simply busy-waits.
 //!
-//! ### `thread_local`
+//! ### thread_local
 //!
 //! The `thread_local` feature provides locking APIs that do not require user-side
 //! node instantiation, but critical sections must be provided as closures. This
@@ -143,7 +143,7 @@
 //! the thread local storage of the waiting threads. Thes locking implementations
 //! will panic if recursively acquired. Not `no_std` compatible.
 //!
-//! ### `lock_api`
+//! ### lock_api
 //!
 //! This feature implements the [`RawMutex`] trait from the [lock_api]
 //! crate for [`barging::Mutex`]. Aliases are provided by the
@@ -180,6 +180,7 @@
 #![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::inline_always)]
+#![allow(clippy::doc_markdown)]
 #![warn(missing_docs)]
 
 pub mod barging;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,12 @@
 //! the thread local storage of the waiting threads. Thes locking implementations
 //! will panic if recursively acquired. Not `no_std` compatible.
 //!
+//! ### lock_api
+//!
+//! This feature implements the [`RawMutex`] trait from the [lock_api]
+//! crate for [`mcslock::Mutex`]. Aliases are provided by the `lock_api` module.
+//! This features is `no_std` compatible.
+//!
 //! ## Related projects
 //!
 //! These projects provide MCS lock implementations with different APIs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@
     no_std
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::inline_always)]
 #![warn(missing_docs)]
@@ -162,9 +163,136 @@
 pub mod raw;
 pub mod relax;
 
+#[cfg(feature = "lock_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lock_api")))]
+pub mod lock_api;
+
 #[cfg(feature = "thread_local")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread_local")))]
 pub mod thread_local;
 
 #[cfg(all(loom, test))]
 pub(crate) mod loom;
+
+mod mutex;
+pub use mutex::{Mutex, MutexGuard};
+
+/// A `test-and-set` MCS lock alias that signals the processor that it is running
+/// a busy-wait spin-loop during lock contention.
+pub mod spins {
+    use crate::relax::Spin;
+
+    /// A `test-and-set` MCS lock that implements the [`Spin`] relax strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::spins::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, Spin>;
+
+    /// A `test-and-set` MCS guard that implements the [`Spin`] relax strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Spin>;
+}
+
+/// A `test-and-set` MCS lock alias that yields the current time slice to the
+/// OS scheduler during lock contention.
+#[cfg(any(feature = "yield", loom, test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "yield")))]
+pub mod yields {
+    use crate::relax::Yield;
+
+    /// A `test-and-set` MCS lock that implements the [`Yield`] relax strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::yields::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, Yield>;
+
+    /// A `test-and-set` MCS guard that implements the [`Yield`] relax strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Yield>;
+}
+
+/// A `test-and-set` MCS lock alias that rapidly spins without telling the CPU
+/// to do any power down during lock contention.
+pub mod loops {
+    use crate::relax::Loop;
+
+    /// A `test-and-set` MCS lock that implements the [`Loop`] relax strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::loops::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, Loop>;
+
+    /// A `test-and-set` MCS guard that implements the [`Loop`] relax strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Loop>;
+}
+
+/// A `test-and-set` MCS lock alias that, during lock contention, will perform
+/// exponential backoff while signaling the processor that it is running a
+/// busy-wait spin-loop.
+pub mod spins_backoff {
+    use crate::relax::SpinBackoff;
+
+    /// A `test-and-set` MCS lock that implements the [`SpinBackoff`] relax
+    /// strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::spins_backoff::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, SpinBackoff>;
+
+    /// A `test-and-set` MCS guard that implements the [`SpinBackoff`] relax
+    /// strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, SpinBackoff>;
+}
+
+/// A `test-and-set` MCS lock alias that, during lock contention, will perform
+/// exponential backoff while spinning up to a threshold, then yields back to
+/// the OS scheduler.
+#[cfg(feature = "yield")]
+#[cfg_attr(docsrs, doc(cfg(feature = "yield")))]
+pub mod yields_backoff {
+    use crate::relax::YieldBackoff;
+
+    /// A `test-and-set` MCS lock that implements the [`YieldBackoff`] relax
+    /// strategy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::yields_backoff::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, YieldBackoff>;
+
+    /// A `test-and-set` MCS guard that implements the [`YieldBackoff`] relax
+    /// strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, YieldBackoff>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,11 +88,11 @@
 //! ## Thread local MCS lock
 //!
 //! This implementation also operates under FIFO. The locking APIs provided
-//! by this module do not require user-side node instantiation, critical
-//! sections must be provided as closures and at most one lock can be held at
-//! any time within a thread. It is not `no_std` compatible and can be enabled
-//! through the `thread_local` feature. See [`mod@thread_local`] module for
-//! more information.
+//! by this module do not require user-side node allocation, critical sections
+//! must be provided as closures and at most one lock can be held at any time
+//! within a thread. It is not `no_std` compatible and can be enabled through
+//! the `thread_local` feature. See [`mod@thread_local`] module for more
+//! information.
 //!
 //! ```
 //! # #[cfg(feature = "thread_local")]
@@ -138,7 +138,7 @@
 //! ### thread_local
 //!
 //! The `thread_local` feature provides locking APIs that do not require user-side
-//! node instantiation, but critical sections must be provided as closures. This
+//! node allocation, but critical sections must be provided as closures. This
 //! implementation handles the queue's nodes transparently, by storing them in
 //! the thread local storage of the waiting threads. Thes locking implementations
 //! will panic if recursively acquired. Not `no_std` compatible.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,8 +155,8 @@
 //! implementation details or compiler requirements, you can check their
 //! repositories:
 //!
-//! - `mcs-rs`: <https://github.com/gereeter/mcs-rs>
-//! - `libmcs`: <https://github.com/topecongiro/libmcs>
+//! - mcs-rs: <https://github.com/gereeter/mcs-rs>
+//! - libmcs: <https://github.com/topecongiro/libmcs>
 //!
 //! [`MutexNode`]: raw::MutexNode
 //! [`std::sync::Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html

--- a/src/lock_api.rs
+++ b/src/lock_api.rs
@@ -3,7 +3,7 @@
 //! This module exports [`lock_api::Mutex`] and [`lock_api::MutexGuard`] aliases
 //! with a `test-and-set` MCS lock and guard as their inner types.
 //!
-//! [`mcslock::Mutex`] implements both [`RawMutex`] and [`RawMutexFair`].
+//! [`mcslock::Mutex`] implements the [`RawMutex`] trait.
 //!
 //! [lock_api]: https://crates.io/crates/lock_api
 //! [`lock_api::Mutex`]: https://docs.rs/lock_api/latest/lock_api/struct.Mutex.html
@@ -39,7 +39,8 @@ pub mod spins {
     /// ```
     pub type Mutex<T> = super::Mutex<T, Spin>;
 
-    /// A `test-and-set` MCS guard that implements the [`Spin`] relax strategy.
+    /// A `test-and-set` MCS guard that implements the [`Spin`] relax strategy
+    /// and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Spin>;
 }
 
@@ -64,7 +65,8 @@ pub mod yields {
     /// ```
     pub type Mutex<T> = super::Mutex<T, Yield>;
 
-    /// A `test-and-set` MCS guard that implements the [`Yield`] relax strategy.
+    /// A `test-and-set` MCS guard that implements the [`Yield`] relax strategy
+    /// and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Yield>;
 }
 
@@ -87,7 +89,8 @@ pub mod loops {
     /// ```
     pub type Mutex<T> = super::Mutex<T, Loop>;
 
-    /// A `test-and-set` MCS guard that implements the [`Loop`] relax strategy.
+    /// A `test-and-set` MCS guard that implements the [`Loop`] relax strategy
+    /// and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Loop>;
 }
 
@@ -112,7 +115,7 @@ pub mod spins_backoff {
     pub type Mutex<T> = super::Mutex<T, SpinBackoff>;
 
     /// A `test-and-set` MCS guard that implements the [`SpinBackoff`] relax
-    /// strategy.
+    /// strategy and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, SpinBackoff>;
 }
 
@@ -139,6 +142,6 @@ pub mod yields_backoff {
     pub type Mutex<T> = super::Mutex<T, YieldBackoff>;
 
     /// A `test-and-set` MCS guard that implements the [`YieldBackoff`] relax
-    /// strategy.
+    /// strategy and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, YieldBackoff>;
 }

--- a/src/lock_api.rs
+++ b/src/lock_api.rs
@@ -39,11 +39,11 @@ pub mod spins {
     /// # Example
     ///
     /// ```
-    /// use mcslock::spins::Mutex;
+    /// use mcslock::lock_api::spins::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, Spin>;
 
@@ -65,11 +65,11 @@ pub mod yields {
     /// # Example
     ///
     /// ```
-    /// use mcslock::yields::Mutex;
+    /// use mcslock::lock_api::yields::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, Yield>;
 
@@ -89,11 +89,11 @@ pub mod loops {
     /// # Example
     ///
     /// ```
-    /// use mcslock::loops::Mutex;
+    /// use mcslock::lock_api::loops::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, Loop>;
 
@@ -114,11 +114,11 @@ pub mod spins_backoff {
     /// # Example
     ///
     /// ```
-    /// use mcslock::spins_backoff::Mutex;
+    /// use mcslock::lock_api::spins_backoff::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, SpinBackoff>;
 
@@ -141,11 +141,11 @@ pub mod yields_backoff {
     /// # Example
     ///
     /// ```
-    /// use mcslock::yields_backoff::Mutex;
+    /// use mcslock::lock_api::yields_backoff::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let data = mutex.lock_with(|guard| *guard);
-    /// assert_eq!(data, 0);
+    /// let guard = mutex.lock();
+    /// assert_eq!(*guard, 0);
     /// ```
     pub type Mutex<T> = super::Mutex<T, YieldBackoff>;
 

--- a/src/lock_api.rs
+++ b/src/lock_api.rs
@@ -1,0 +1,144 @@
+//! Locking interfaces for MCS lock that are compatible with [lock_api].
+//!
+//! This module exports [`lock_api::Mutex`] and [`lock_api::MutexGuard`] aliases
+//! with a `test-and-set` MCS lock and guard as their inner types.
+//!
+//! [`mcslock::Mutex`] implements both [`RawMutex`] and [`RawMutexFair`].
+//!
+//! [lock_api]: https://crates.io/crates/lock_api
+//! [`lock_api::Mutex`]: https://docs.rs/lock_api/latest/lock_api/struct.Mutex.html
+//! [`lock_api::MutexGuard`]: https://docs.rs/lock_api/latest/lock_api/struct.MutexGuard.html
+//! [`mcslock::Mutex`]: crate::Mutex
+//! [`RawMutex`]: https://docs.rs/lock_api/latest/lock_api/trait.RawMutex.html
+//! [`RawMutexFair`]: https://docs.rs/lock_api/latest/lock_api/trait.RawMutexFair.html
+
+/// A lock that provides mutually exclusive data access that is compatible with
+/// [`lock_api`](https://crates.io/crates/lock_api).
+pub type Mutex<T, R> = lock_api::Mutex<crate::Mutex<(), R>, T>;
+
+/// A guard that provides mutable data access that is compatible with
+/// [`lock_api`](https://crates.io/crates/lock_api).
+pub type MutexGuard<'a, T, R> = lock_api::MutexGuard<'a, crate::Mutex<(), R>, T>;
+
+/// A `test-and-set` MCS lock alias that signals the processor that it is running
+/// a busy-wait spin-loop during lock contention.
+pub mod spins {
+    use crate::relax::Spin;
+
+    /// A `test-and-set` MCS lock that implements the [`Spin`] relax strategy
+    /// and compatible with the `lock_api` crate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::spins::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, Spin>;
+
+    /// A `test-and-set` MCS guard that implements the [`Spin`] relax strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Spin>;
+}
+
+/// A `test-and-set` MCS lock alias that yields the current time slice to the
+/// OS scheduler during lock contention.
+#[cfg(any(feature = "yield", loom, test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "yield")))]
+pub mod yields {
+    use crate::relax::Yield;
+
+    /// A `test-and-set` MCS lock that implements the [`Yield`] relax strategy
+    /// and compatible with the `lock_api` crate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::yields::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, Yield>;
+
+    /// A `test-and-set` MCS guard that implements the [`Yield`] relax strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Yield>;
+}
+
+/// A `test-and-set` MCS lock alias that rapidly spins without telling the CPU
+/// to do any power down during lock contention.
+pub mod loops {
+    use crate::relax::Loop;
+
+    /// A `test-and-set` MCS lock that implements the [`Loop`] relax strategy
+    /// and compatible with the `lock_api` crate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::loops::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, Loop>;
+
+    /// A `test-and-set` MCS guard that implements the [`Loop`] relax strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Loop>;
+}
+
+/// A `test-and-set` MCS lock alias that, during lock contention, will perform
+/// exponential backoff while signaling the processor that it is running a
+/// busy-wait spin-loop.
+pub mod spins_backoff {
+    use crate::relax::SpinBackoff;
+
+    /// A `test-and-set` MCS lock that implements the [`SpinBackoff`] relax
+    /// strategy and compatible with the `lock_api` crate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::spins_backoff::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, SpinBackoff>;
+
+    /// A `test-and-set` MCS guard that implements the [`SpinBackoff`] relax
+    /// strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, SpinBackoff>;
+}
+
+/// A `test-and-set` MCS lock alias that, during lock contention, will perform
+/// exponential backoff while spinning up to a threshold, then yields back to
+/// the OS scheduler.
+#[cfg(feature = "yield")]
+#[cfg_attr(docsrs, doc(cfg(feature = "yield")))]
+pub mod yields_backoff {
+    use crate::relax::YieldBackoff;
+
+    /// A `test-and-set` MCS lock that implements the [`YieldBackoff`] relax
+    /// strategy and compatible with the `lock_api` crate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mcslock::yields_backoff::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// let data = mutex.lock_with(|guard| *guard);
+    /// assert_eq!(data, 0);
+    /// ```
+    pub type Mutex<T> = super::Mutex<T, YieldBackoff>;
+
+    /// A `test-and-set` MCS guard that implements the [`YieldBackoff`] relax
+    /// strategy.
+    pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, YieldBackoff>;
+}

--- a/src/lock_api.rs
+++ b/src/lock_api.rs
@@ -1,15 +1,23 @@
 //! Locking interfaces for MCS lock that are compatible with [lock_api].
 //!
-//! This module exports [`lock_api::Mutex`] and [`lock_api::MutexGuard`] aliases
-//! with a `barging` MCS lock and guard as their inner types.
+//! This module exports [`lock_api::Mutex`] and [`lock_api::MutexGuard`] type
+//! aliases with a `barging` MCS lock and guard as their inner types. The
+//! [`barging::Mutex`] type will implement the [`lock_api::RawMutex`] trait when
+//! this feature is enabled.
 //!
-//! [`mcslock::Mutex`] implements the [`RawMutex`] trait.
+//! The Mutex is generic over the relax strategy. User may choose a strategy
+//! as long as it implements the [`Relax`] trait. There is a number of strategies
+//! provided by the [`relax`] module. The following modules provide type aliases
+//! for [`lock_api::Mutex`] and [`lock_api::MutexGuard`] associated with one
+//! relax strategy. See their documentation for more information.
 //!
+//! [`relax`]: crate::relax
+//! [`Relax`]: crate::relax::Relax
+//! [`barging::Mutex`]: crate::barging::Mutex
 //! [lock_api]: https://crates.io/crates/lock_api
 //! [`lock_api::Mutex`]: https://docs.rs/lock_api/latest/lock_api/struct.Mutex.html
 //! [`lock_api::MutexGuard`]: https://docs.rs/lock_api/latest/lock_api/struct.MutexGuard.html
-//! [`mcslock::Mutex`]: crate::Mutex
-//! [`RawMutex`]: https://docs.rs/lock_api/latest/lock_api/trait.RawMutex.html
+//! [`lock_api::RawMutex`]: https://docs.rs/lock_api/latest/lock_api/trait.RawMutex.html
 //! [`RawMutexFair`]: https://docs.rs/lock_api/latest/lock_api/trait.RawMutexFair.html
 
 /// A lock that provides mutually exclusive data access that is compatible with

--- a/src/lock_api.rs
+++ b/src/lock_api.rs
@@ -1,7 +1,7 @@
 //! Locking interfaces for MCS lock that are compatible with [lock_api].
 //!
 //! This module exports [`lock_api::Mutex`] and [`lock_api::MutexGuard`] aliases
-//! with a `test-and-set` MCS lock and guard as their inner types.
+//! with a `barging` MCS lock and guard as their inner types.
 //!
 //! [`mcslock::Mutex`] implements the [`RawMutex`] trait.
 //!
@@ -14,18 +14,18 @@
 
 /// A lock that provides mutually exclusive data access that is compatible with
 /// [`lock_api`](https://crates.io/crates/lock_api).
-pub type Mutex<T, R> = lock_api::Mutex<crate::Mutex<(), R>, T>;
+pub type Mutex<T, R> = lock_api::Mutex<crate::barging::Mutex<(), R>, T>;
 
 /// A guard that provides mutable data access that is compatible with
 /// [`lock_api`](https://crates.io/crates/lock_api).
-pub type MutexGuard<'a, T, R> = lock_api::MutexGuard<'a, crate::Mutex<(), R>, T>;
+pub type MutexGuard<'a, T, R> = lock_api::MutexGuard<'a, crate::barging::Mutex<(), R>, T>;
 
-/// A `test-and-set` MCS lock alias that signals the processor that it is running
+/// A `barging` MCS lock alias that signals the processor that it is running
 /// a busy-wait spin-loop during lock contention.
 pub mod spins {
     use crate::relax::Spin;
 
-    /// A `test-and-set` MCS lock that implements the [`Spin`] relax strategy
+    /// A `barging` MCS lock that implements the [`Spin`] relax strategy
     /// and compatible with the `lock_api` crate.
     ///
     /// # Example
@@ -39,19 +39,19 @@ pub mod spins {
     /// ```
     pub type Mutex<T> = super::Mutex<T, Spin>;
 
-    /// A `test-and-set` MCS guard that implements the [`Spin`] relax strategy
+    /// A `barging` MCS guard that implements the [`Spin`] relax strategy
     /// and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Spin>;
 }
 
-/// A `test-and-set` MCS lock alias that yields the current time slice to the
+/// A `barging` MCS lock alias that yields the current time slice to the
 /// OS scheduler during lock contention.
 #[cfg(any(feature = "yield", loom, test))]
 #[cfg_attr(docsrs, doc(cfg(feature = "yield")))]
 pub mod yields {
     use crate::relax::Yield;
 
-    /// A `test-and-set` MCS lock that implements the [`Yield`] relax strategy
+    /// A `barging` MCS lock that implements the [`Yield`] relax strategy
     /// and compatible with the `lock_api` crate.
     ///
     /// # Example
@@ -65,17 +65,17 @@ pub mod yields {
     /// ```
     pub type Mutex<T> = super::Mutex<T, Yield>;
 
-    /// A `test-and-set` MCS guard that implements the [`Yield`] relax strategy
+    /// A `barging` MCS guard that implements the [`Yield`] relax strategy
     /// and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Yield>;
 }
 
-/// A `test-and-set` MCS lock alias that rapidly spins without telling the CPU
+/// A `barging` MCS lock alias that rapidly spins without telling the CPU
 /// to do any power down during lock contention.
 pub mod loops {
     use crate::relax::Loop;
 
-    /// A `test-and-set` MCS lock that implements the [`Loop`] relax strategy
+    /// A `barging` MCS lock that implements the [`Loop`] relax strategy
     /// and compatible with the `lock_api` crate.
     ///
     /// # Example
@@ -89,18 +89,18 @@ pub mod loops {
     /// ```
     pub type Mutex<T> = super::Mutex<T, Loop>;
 
-    /// A `test-and-set` MCS guard that implements the [`Loop`] relax strategy
+    /// A `barging` MCS guard that implements the [`Loop`] relax strategy
     /// and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, Loop>;
 }
 
-/// A `test-and-set` MCS lock alias that, during lock contention, will perform
+/// A `barging` MCS lock alias that, during lock contention, will perform
 /// exponential backoff while signaling the processor that it is running a
 /// busy-wait spin-loop.
 pub mod spins_backoff {
     use crate::relax::SpinBackoff;
 
-    /// A `test-and-set` MCS lock that implements the [`SpinBackoff`] relax
+    /// A `barging` MCS lock that implements the [`SpinBackoff`] relax
     /// strategy and compatible with the `lock_api` crate.
     ///
     /// # Example
@@ -114,12 +114,12 @@ pub mod spins_backoff {
     /// ```
     pub type Mutex<T> = super::Mutex<T, SpinBackoff>;
 
-    /// A `test-and-set` MCS guard that implements the [`SpinBackoff`] relax
+    /// A `barging` MCS guard that implements the [`SpinBackoff`] relax
     /// strategy and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, SpinBackoff>;
 }
 
-/// A `test-and-set` MCS lock alias that, during lock contention, will perform
+/// A `barging` MCS lock alias that, during lock contention, will perform
 /// exponential backoff while spinning up to a threshold, then yields back to
 /// the OS scheduler.
 #[cfg(feature = "yield")]
@@ -127,7 +127,7 @@ pub mod spins_backoff {
 pub mod yields_backoff {
     use crate::relax::YieldBackoff;
 
-    /// A `test-and-set` MCS lock that implements the [`YieldBackoff`] relax
+    /// A `barging` MCS lock that implements the [`YieldBackoff`] relax
     /// strategy and compatible with the `lock_api` crate.
     ///
     /// # Example
@@ -141,7 +141,7 @@ pub mod yields_backoff {
     /// ```
     pub type Mutex<T> = super::Mutex<T, YieldBackoff>;
 
-    /// A `test-and-set` MCS guard that implements the [`YieldBackoff`] relax
+    /// A `barging` MCS guard that implements the [`YieldBackoff`] relax
     /// strategy and compatible with the `lock_api` crate.
     pub type MutexGuard<'a, T> = super::MutexGuard<'a, T, YieldBackoff>;
 }

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::needless_pass_by_value)]
 #![allow(clippy::redundant_pub_crate)]
 
 use core::marker::PhantomData;

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -1,13 +1,22 @@
-//! A MCS lock implementation that is compliant with `lock_api` crate.
+//! A MCS lock implementation that is compliant with the `lock_api` crate.
+//!
+//! The lock is hold for as long as its associated RAII guard is in scope. Once
+//! the guard is dropped, the mutex is freed. Mutex guards are returned by
+//! [`lock`] and [`try_lock`]. Guards are also accessible as the closure argument
+//! for [`lock_with`] and [`try_lock_with`] methods.
 //!
 //! The Mutex is generic over the relax strategy. User may choose a strategy
 //! as long as it implements the [`Relax`] trait. There is a number of strategies
-//! provided by the [`relax`] module. The default relax strategy is [`Spin`].
-//! See their documentation for more information.
+//! provided by the [`relax`] module. Each submodule provides type aliases for
+//! [`Mutex`] and [`MutexGuard`] associated with one relax strategy. See their
+//! documentation for more information.
 //!
+//! [`lock`]: Mutex::lock
+//! [`try_lock`]: Mutex::try_lock
+//! [`lock_with`]: Mutex::lock_with
+//! [`try_lock_with`]: Mutex::try_lock_with
 //! [`relax`]: crate::relax
 //! [`Relax`]: crate::relax::Relax
-//! [`Spin`]: crate::relax::Spin
 
 use core::fmt;
 use core::marker::PhantomData;

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1,5 +1,5 @@
-//! A MCS lock implementation that requires instantiation and exclusive access
-//! to a queue node.
+//! A MCS lock implementation that requires exclusive access to a locally
+//! accessible queue node.
 //!
 //! The `raw` implementation of MCS lock is fair, that is, it guarantees that
 //! thread that have waited for longer will be scheduled first (FIFO). Each
@@ -7,7 +7,7 @@
 //! state, which then avoids the network contention of the state access.
 //!
 //! This module provides an implementation that is `no_std` compatible, but
-//! also requires that queue nodes must be instantiated by the callers. Queue
+//! also requires that queue nodes must be allocated by the callers. Queue
 //! nodes are represented by the [`MutexNode`] type.
 //!
 //! The lock is hold for as long as its associated RAII guard is in scope. Once

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1,13 +1,19 @@
 //! A MCS lock implementation that requires instantiation and exclusive access
 //! to a queue node.
 //!
-//! The `raw` module provides an implementation that is `no_std` compatible, but
+//! The `raw` implementation of MCS lock is fair, that is, it guarantees that
+//! thread that have waited for longer will be scheduled first (FIFO). Each
+//! waiting thread will spin against its own, locally-accessible atomic lock
+//! state, which then avoids the network contention of the state access.
+//!
+//! This module provides an implementation that is `no_std` compatible, but
 //! also requires that queue nodes must be instantiated by the callers. Queue
-//! nodes are represented by the [`MutexNode`] type. The lock is hold for as
-//! long as its associated RAII guard is in scope. Once the guard is dropped,
-//! the mutex is freed. Mutex guards are returned by [`lock`] and [`try_lock`].
-//! Guards are also accessible as the closure argument for [`lock_with`] and
-//! [`try_lock_with`] methods.
+//! nodes are represented by the [`MutexNode`] type.
+//!
+//! The lock is hold for as long as its associated RAII guard is in scope. Once
+//! the guard is dropped, the mutex is freed. Mutex guards are returned by
+//! [`lock`] and [`try_lock`]. Guards are also accessible as the closure argument
+//! for [`lock_with`] and [`try_lock_with`] methods.
 //!
 //! The Mutex is generic over the relax strategy. User may choose a strategy
 //! as long as it implements the [`Relax`] trait. There is a number of strategies

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -11,9 +11,9 @@
 //!
 //! The Mutex is generic over the relax strategy. User may choose a strategy
 //! as long as it implements the [`Relax`] trait. There is a number of strategies
-//! provided by the [`relax`] module. The default relax strategy is [`Spin`].
-//! Each module in `raw` provides type aliases for [`Mutex`] and [`MutexGuard`]
-//! associated with one relax strategy. See their documentation for more information.
+//! provided by the [`relax`] module. Each module in `raw` provides type aliases
+//! for [`Mutex`] and [`MutexGuard`] associated with one relax strategy. See
+//! their documentation for more information.
 //!
 //! [`lock`]: Mutex::lock
 //! [`try_lock`]: Mutex::try_lock
@@ -21,7 +21,6 @@
 //! [`try_lock_with`]: Mutex::try_lock_with
 //! [`relax`]: crate::relax
 //! [`Relax`]: crate::relax::Relax
-//! [`Spin`]: crate::relax::Spin
 
 mod mutex;
 pub use mutex::{Mutex, MutexGuard, MutexNode};

--- a/src/raw/mutex.rs
+++ b/src/raw/mutex.rs
@@ -342,7 +342,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
         if !pred.is_null() {
             // SAFETY: Already verified that predecessor is not null.
             unsafe { &*pred }.next.store(node.as_ptr(), Release);
-            let mut relax = R::new();
+            let mut relax = R::default();
             while node.locked.load(Relaxed) {
                 relax.relax();
             }
@@ -408,7 +408,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
             let false = self.try_unlock(node.as_ptr()) else { return };
             // But if we are not the tail, then we have a pending successor. We
             // must wait for them to finish linking with us.
-            let mut relax = R::new();
+            let mut relax = R::default();
             loop {
                 next = node.next.load(Relaxed);
                 let true = next.is_null() else { break };

--- a/src/relax.rs
+++ b/src/relax.rs
@@ -64,7 +64,7 @@ impl Relax for Spin {
 #[cfg_attr(docsrs, doc(cfg(feature = "yield")))]
 pub struct Yield;
 
-#[cfg(any(feature = "yield", all(test, not(loom))))]
+#[cfg(any(all(feature = "yield", not(loom)), all(test, not(loom))))]
 impl Relax for Yield {
     #[inline(always)]
     fn new() -> Self {

--- a/src/thread_local/mod.rs
+++ b/src/thread_local/mod.rs
@@ -1,6 +1,11 @@
 //! A MCS lock implementation that stores queue nodes in the thread local
 //! storage of the waiting threads.
 //!
+//! The `thread_local` implementation of MCS lock is fair, that is, it
+//! guarantees that thread that have waited for longer will be scheduled first
+//! (FIFO). Each waiting thread will spin against its own, thread local atomic
+//! lock state, which then avoids the network contention of the state access.
+//!
 //! This module provide MCS locking APIs that do not require user-side node
 //! instantiation, by managing the queue's nodes allocations internally. Queue
 //! nodes are stored in the thread local storage, therefore this implementation

--- a/src/thread_local/mod.rs
+++ b/src/thread_local/mod.rs
@@ -11,10 +11,9 @@
 //!
 //! The Mutex is generic over the relax strategy. User may choose a strategy
 //! as long as it implements the [`Relax`] trait. There is a number of strategies
-//! provided by the [`relax`] module. The default relax strategy is [`Spin`].
-//! Each module in `thread_local` provides type aliases for [`Mutex`] and
-//! [`MutexGuard`] associated with one relax strategy. See their documentation
-//! for more information.
+//! provided by the [`relax`] module. Each module in `thread_local` provides type
+//! aliases for [`Mutex`] and [`MutexGuard`] associated with one relax strategy.
+//! See their documentation for more information.
 //!
 //! # Panics
 //!
@@ -26,7 +25,6 @@
 //! [`try_lock_with`]: Mutex::try_lock_with
 //! [`relax`]: crate::relax
 //! [`Relax`]: crate::relax::Relax
-//! [`Spin`]: crate::relax::Spin
 
 mod mutex;
 pub use mutex::{Mutex, MutexGuard};

--- a/src/thread_local/mod.rs
+++ b/src/thread_local/mod.rs
@@ -7,7 +7,7 @@
 //! lock state, which then avoids the network contention of the state access.
 //!
 //! This module provide MCS locking APIs that do not require user-side node
-//! instantiation, by managing the queue's nodes allocations internally. Queue
+//! allocation, by managing the queue's node allocations internally. Queue
 //! nodes are stored in the thread local storage, therefore this implementation
 //! requires support from the standard library. Critical sections must be
 //! provided to [`lock_with`] and [`try_lock_with`] as closures. Closure arguments
@@ -22,9 +22,10 @@
 //!
 //! # Panics
 //!
-//! The `thread_local` [`Mutex`] implementation does not allow recursive locking,
-//! doing so will cause a panic. See [`lock_with`] and [`try_lock_with`] functions
-//! for more information.
+//! The `thread_local` [`Mutex`] implementation only allows at most on lock held
+//! within a single thread at any time. Trying to acquire a second lock while a
+//! guard is alive will cause a panic. See [`lock_with`] and [`try_lock_with`]
+//! functions for more information.
 //!
 //! [`lock_with`]: Mutex::lock_with
 //! [`try_lock_with`]: Mutex::try_lock_with

--- a/src/thread_local/mutex.rs
+++ b/src/thread_local/mutex.rs
@@ -161,6 +161,15 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     /// assert_eq!(mutex.lock_with(|guard| *guard), 10);
     /// ```
     ///
+    /// Borrows of the guard or its data cannot escape the given closure.
+    ///
+    /// ```compile_fail,E0515
+    /// use mcslock::thread_local::spins::Mutex;
+    ///
+    /// let mutex = Mutex::new(1);
+    /// let data = mutex.try_lock_with(|guard| &*guard.unwrap());
+    /// ```
+    ///
     /// An example of panic:
     ///
     /// ```should_panic
@@ -220,6 +229,15 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     /// .join().expect("thread::spawn failed");
     ///
     /// assert_eq!(mutex.lock_with(|guard| *guard), 10);
+    /// ```
+    ///
+    /// Borrows of the guard or its data cannot escape the given closure.
+    ///
+    /// ```compile_fail,E0515
+    /// use mcslock::thread_local::spins::Mutex;
+    ///
+    /// let mutex = Mutex::new(1);
+    /// let data = mutex.lock_with(|guard| &*guard);
     /// ```
     ///
     /// An example of panic:
@@ -456,19 +474,6 @@ mod test {
         let data = m.lock_with(|guard| *guard);
         assert_eq!(data, 2);
     }
-
-    // #[test]
-    // fn must_not_compile() {
-    //     let m = Mutex::new(1);
-    //     let guard = m.lock_with(|guard| guard);
-    //     let _value = *guard;
-
-    //     let m = Mutex::new(1);
-    //     let _val = m.lock_with(|guard| &mut *guard);
-
-    //     let m = Mutex::new(1);
-    //     let _val = m.lock_with(|guard| &*guard);
-    // }
 
     #[test]
     fn lots_and_lots() {

--- a/src/thread_local/mutex.rs
+++ b/src/thread_local/mutex.rs
@@ -20,12 +20,6 @@ use crate::relax::Relax;
 /// provided as closure arguments from [`lock_with`] and [`try_lock_with`], which
 /// guarantees that the data is only ever accessed when the mutex is locked.
 ///
-/// # Panics
-///
-/// The `thread_local` [`Mutex`] implementation does not allow recursive locking,
-/// doing so will cause a panic. See [`lock_with`] and [`try_lock_with`] functions
-/// for more information.
-///
 /// # Examples
 ///
 /// ```
@@ -133,9 +127,9 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     ///
     /// # Panics
     ///
-    /// This lock implementation cannot be recursively acquired, doing so it
-    /// result in a panic. That is the case for both `lock_with` and
-    /// `try_lock_with`.
+    /// At most one lock of this implementation might be held within a single
+    /// thread at any time. Trying to acquire a second lock while a guard is
+    /// still alive will cause a panic.
     ///
     /// # Examples
     ///
@@ -205,9 +199,9 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     ///
     /// # Panics
     ///
-    /// This lock implementation cannot be recursively acquired, doing so it
-    /// result in a panic. That is the case for both `lock_with` and
-    /// `try_lock_with`.
+    /// At most one lock of this implementation might be held within a single
+    /// thread at any time. Trying to acquire a second lock while a guard is
+    /// still alive will cause a panic.
     ///
     /// # Examples
     ///

--- a/tests/lock_api.rs
+++ b/tests/lock_api.rs
@@ -1,0 +1,168 @@
+// Test suite from the Rust's Mutex implementation with minor modifications
+// since the API is not compatible with this crate implementation and some
+// new tests as well.
+//
+// Copyright 2014 The Rust Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::thread;
+
+use mcslock::lock_api::yields::Mutex;
+
+#[derive(Eq, PartialEq, Debug)]
+struct NonCopy(i32);
+
+#[test]
+fn smoke() {
+    let m = Mutex::new(());
+    drop(m.lock());
+    drop(m.lock());
+}
+
+#[test]
+fn lots_and_lots() {
+    static LOCK: Mutex<u32> = Mutex::new(0);
+
+    const ITERS: u32 = 1000;
+    const CONCURRENCY: u32 = 3;
+
+    fn inc() {
+        for _ in 0..ITERS {
+            let mut g = LOCK.lock();
+            *g += 1;
+        }
+    }
+
+    let (tx, rx) = channel();
+    for _ in 0..CONCURRENCY {
+        let tx2 = tx.clone();
+        thread::spawn(move || {
+            inc();
+            tx2.send(()).unwrap();
+        });
+        let tx2 = tx.clone();
+        thread::spawn(move || {
+            inc();
+            tx2.send(()).unwrap();
+        });
+    }
+
+    drop(tx);
+    for _ in 0..2 * CONCURRENCY {
+        rx.recv().unwrap();
+    }
+    assert_eq!(*LOCK.lock(), ITERS * CONCURRENCY * 2);
+}
+
+#[test]
+fn try_lock() {
+    let m = Mutex::new(());
+    *m.try_lock().unwrap() = ();
+}
+
+#[test]
+fn test_into_inner() {
+    let m = Mutex::new(NonCopy(10));
+    assert_eq!(m.into_inner(), NonCopy(10));
+}
+
+#[test]
+fn test_into_inner_drop() {
+    struct Foo(Arc<AtomicUsize>);
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    let num_drops = Arc::new(AtomicUsize::new(0));
+    let m = Mutex::new(Foo(num_drops.clone()));
+    assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+    {
+        let _inner = m.into_inner();
+        assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+    }
+    assert_eq!(num_drops.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn test_get_mut() {
+    let mut m = Mutex::new(NonCopy(10));
+    *m.get_mut() = NonCopy(20);
+    assert_eq!(m.into_inner(), NonCopy(20));
+}
+
+#[test]
+fn test_lock_arc_nested() {
+    // Tests nested locks and access
+    // to underlying data.
+    let arc = Arc::new(Mutex::new(1));
+    let arc2 = Arc::new(Mutex::new(arc));
+    let (tx, rx) = channel();
+    let _t = thread::spawn(move || {
+        let lock = arc2.lock();
+        let lock2 = lock.lock();
+        assert_eq!(*lock2, 1);
+        tx.send(()).unwrap();
+    });
+    rx.recv().unwrap();
+}
+
+#[test]
+fn test_recursive_lock() {
+    let arc = Arc::new(Mutex::new(1));
+    let (tx, rx) = channel();
+    for _ in 0..4 {
+        let tx2 = tx.clone();
+        let c_arc = Arc::clone(&arc);
+        let _t = thread::spawn(move || {
+            let mutex = Mutex::new(1);
+            let _lock = c_arc.lock();
+            let lock2 = mutex.lock();
+            assert_eq!(*lock2, 1);
+            tx2.send(()).unwrap();
+        });
+    }
+    drop(tx);
+    rx.recv().unwrap();
+}
+
+#[test]
+fn test_lock_arc_access_in_unwind() {
+    let arc = Arc::new(Mutex::new(1));
+    let arc2 = arc.clone();
+    let _ = thread::spawn(move || -> () {
+        struct Unwinder {
+            i: Arc<Mutex<i32>>,
+        }
+        impl Drop for Unwinder {
+            fn drop(&mut self) {
+                *self.i.lock() += 1;
+            }
+        }
+        let _u = Unwinder { i: arc2 };
+        panic!();
+    })
+    .join();
+    let lock = arc.lock();
+    assert_eq!(*lock, 2);
+}
+
+#[test]
+fn test_lock_unsized() {
+    let lock: &Mutex<[i32]> = &Mutex::new([1, 2, 3]);
+    {
+        let b = &mut *lock.lock();
+        b[0] = 4;
+        b[2] = 5;
+    }
+    let comp: &[i32] = &[4, 2, 5];
+    assert_eq!(&*lock.lock(), comp);
+}


### PR DESCRIPTION
This PR adds a _barging_ MCS lock implementation. This lock implements barging instead of  forcing FIFO, which can achieve a higher throughput when the lock is heavily contended. This PR also integrates the barging MCS lock implementation with the [lock_api](https://docs.rs/lock_api/latest/lock_api/) crate, under the optional `lock_api` feature.