### PR TITLE
Add thread local unchecked APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ mechanism are:
 - works equally well (requiring only O(1) network transactions per lock
   acquisition) on machines with and without coherent caches.
 
-This algorithm and serveral others were introduced by [Mellor-Crummey and Scott] paper.
+This algorithm and several others were introduced by [Mellor-Crummey and Scott] paper.
 And a simpler correctness proof of the MCS lock was proposed by [Johnson and Harathi].
 
 ## Use cases
@@ -29,7 +29,7 @@ majority of use cases are well covered by OS-based mutexes like
 the system that the waiting thread should be parked, freeing the processor to
 work on something else.
 
-Spinlocks are only efficient in very few circunstances where the overhead
+Spinlocks are only efficient in very few circumstances where the overhead
 of context switching or process rescheduling are greater than busy waiting
 for very short periods. Spinlocks can be useful inside operating-system kernels,
 on embedded systems or even complement other locking designs. As a reference
@@ -51,7 +51,7 @@ Or add a entry under the `[dependencies]` section in your `Cargo.toml`:
 # Cargo.toml
 
 [dependencies]
-# Avaliable features: `yield`, `barging`, `thread_local` and `lock_api`.
+# Available features: `yield`, `barging`, `thread_local` and `lock_api`.
 mcslock = { version = "0.1", features = ["barging"] }
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ is heavily contended.
 The `thread_local` feature provides locking APIs that do not require user-side
 node allocation, but critical sections must be provided as closures. This
 implementation handles the queue's nodes transparently, by storing them in
-the thread local storage of the waiting threads. These locking implementations
-will panic if recursively acquired. Not `no_std` compatible.
+the thread local storage of the waiting threads. This locking implementation
+will panic if more than one guard is alive within a single thread. Not
+`no_std` compatible.
 
 ### lock_api
 

--- a/src/barging/mutex.rs
+++ b/src/barging/mutex.rs
@@ -582,9 +582,7 @@ mod test {
 
     #[test]
     fn lots_and_lots() {
-        use std::sync::Arc;
-        let data = Arc::new(Mutex::new(0));
-        tests::lots_and_lots(&data);
+        tests::lots_and_lots::<Mutex<_>>();
     }
 
     #[test]

--- a/src/barging/mutex.rs
+++ b/src/barging/mutex.rs
@@ -118,7 +118,7 @@ impl<T, R> Mutex<T, R> {
 }
 
 impl<T: ?Sized, R: Relax> Mutex<T, R> {
-    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    /// Acquires this mutex, blocking the current thread until it is able to do so.
     ///
     /// This function will block the local thread until it is available to acquire
     /// the mutex. Upon returning, the thread is the only thread with the lock
@@ -167,7 +167,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
         MutexGuard::new(self)
     }
 
-    /// Acquires a mutex and then runs the closure against its guard.
+    /// Acquires this mutex and then runs the closure against its guard.
     ///
     /// This function will block the local thread until it is available to acquire
     /// the mutex. Upon acquiring the mutex, the user provided closure will be
@@ -216,7 +216,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
 }
 
 impl<T: ?Sized, R> Mutex<T, R> {
-    /// Attempts to acquire this lock.
+    /// Attempts to acquire this mutex without blocking the thread.
     ///
     /// If the lock could not be acquired at this time, then [`None`] is returned.
     /// Otherwise, an RAII guard is returned. The lock will be unlocked when the
@@ -260,7 +260,7 @@ impl<T: ?Sized, R> Mutex<T, R> {
             .ok()
     }
 
-    /// Attempts to acquire this lock and then runs the closure against its guard.
+    /// Attempts to acquire this mutex and then runs a closure against its guard.
     ///
     /// If the lock could not be acquired at this time, then a [`None`] value is
     /// given to the user provided closure as the argument. If the lock has been

--- a/src/barging/mutex.rs
+++ b/src/barging/mutex.rs
@@ -263,9 +263,9 @@ impl<T: ?Sized, R> Mutex<T, R> {
     /// Attempts to acquire this mutex and then runs a closure against its guard.
     ///
     /// If the lock could not be acquired at this time, then a [`None`] value is
-    /// given to the user provided closure as the argument. If the lock has been
-    /// acquired, then a [`Some`] with the mutex guard is given instead. The lock
-    /// will be unlocked when the guard is dropped.
+    /// given back as the closure argument. If the lock has been acquired, then
+    /// a [`Some`] value with the mutex guard is given instead. The lock will be
+    /// unlocked when the guard is dropped.
     ///
     /// This function does not block.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@
 //! node allocation, but critical sections must be provided as closures. This
 //! implementation handles the queue's nodes transparently, by storing them in
 //! the thread local storage of the waiting threads. This locking implementation
-//! will panic more than one guard is alive within a single thread. Not
+//! will panic if more than one guard is alive within a single thread. Not
 //! `no_std` compatible.
 //!
 //! ### lock_api

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,9 @@
 //! The `thread_local` feature provides locking APIs that do not require user-side
 //! node allocation, but critical sections must be provided as closures. This
 //! implementation handles the queue's nodes transparently, by storing them in
-//! the thread local storage of the waiting threads. Thes locking implementations
-//! will panic if recursively acquired. Not `no_std` compatible.
+//! the thread local storage of the waiting threads. This locking implementation
+//! will panic more than one guard is alive within a single thread. Not
+//! `no_std` compatible.
 //!
 //! ### lock_api
 //!

--- a/src/lock_api/mutex.rs
+++ b/src/lock_api/mutex.rs
@@ -72,9 +72,7 @@ mod test {
 
     #[test]
     fn lots_and_lots() {
-        use std::sync::Arc;
-        let data = Arc::new(Mutex::new(0));
-        tests::lots_and_lots(&data);
+        tests::lots_and_lots::<Mutex<_>>();
     }
 
     #[test]

--- a/src/raw/mutex.rs
+++ b/src/raw/mutex.rs
@@ -196,7 +196,7 @@ impl<T, R> Mutex<T, R> {
 }
 
 impl<T: ?Sized, R: Relax> Mutex<T, R> {
-    /// Attempts to acquire this lock.
+    /// Attempts to acquire this mutex without blocking the thread.
     ///
     /// If the lock could not be acquired at this time, then [`None`] is returned.
     /// Otherwise, an RAII guard is returned. The lock will be unlocked when the
@@ -243,13 +243,12 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
             .ok()
     }
 
-    /// Attempts to acquire this lock and then runs the closure against its guard.
+    /// Attempts to acquire this mutex and then runs a closure against its guard.
     ///
     /// If the lock could not be acquired at this time, then a [`None`] value is
-    /// given to the user provided closure as the argument. If the lock has been
-    /// acquired, then a [`Some`] with the mutex guard is given instead. The lock
-    /// will be unlocked when the guard is dropped.
-    ///
+    /// given back as the closure argument. If the lock has been acquired, then
+    /// a [`Some`] value with the mutex guard is given instead. The lock will be
+    /// unlocked when the guard is dropped.
     /// This function does not block.
     ///
     /// # Examples
@@ -297,7 +296,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
         f(self.try_lock(&mut node))
     }
 
-    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    /// Acquires this mutex, blocking the current thread until it is able to do so.
     ///
     /// This function will block the local thread until it is available to acquire
     /// the mutex. Upon returning, the thread is the only thread with the lock
@@ -348,7 +347,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
         MutexGuard::new(self, node)
     }
 
-    /// Acquires a mutex and then runs the closure against its guard.
+    /// Acquires this mutex and then runs the closure against its guard.
     ///
     /// This function will block the local thread until it is available to acquire
     /// the mutex. Upon acquiring the mutex, the user provided closure will be

--- a/src/raw/mutex.rs
+++ b/src/raw/mutex.rs
@@ -249,9 +249,8 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     /// given back as the closure argument. If the lock has been acquired, then
     /// a [`Some`] value with the mutex guard is given instead. The lock will be
     /// unlocked when the guard is dropped.
-    /// This function does not block.
     ///
-    /// # Examples
+    /// This function does not block.
     ///
     /// ```
     /// use std::sync::Arc;

--- a/src/raw/mutex.rs
+++ b/src/raw/mutex.rs
@@ -660,9 +660,7 @@ mod test {
 
     #[test]
     fn lots_and_lots() {
-        use std::sync::Arc;
-        let data = Arc::new(Mutex::new(0));
-        tests::lots_and_lots(&data);
+        tests::lots_and_lots::<Mutex<_>>();
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -86,7 +86,7 @@ pub mod tests {
         }
     }
 
-    pub fn lots_and_lots<L>(data: &Arc<L>)
+    pub fn lots_and_lots<L>()
     where
         L: LockWith<Target = Int> + Send + Sync + 'static,
     {
@@ -99,15 +99,16 @@ pub mod tests {
             }
         }
 
+        let data = Arc::new(L::new(0));
         let (tx, rx) = channel();
         for _ in 0..CONCURRENCY {
-            let data1 = Arc::clone(data);
+            let data1 = Arc::clone(&data);
             let tx2 = tx.clone();
             thread::spawn(move || {
                 inc(&data1);
                 tx2.send(()).unwrap();
             });
-            let data2 = Arc::clone(data);
+            let data2 = Arc::clone(&data);
             let tx2 = tx.clone();
             thread::spawn(move || {
                 inc(&data2);

--- a/src/thread_local/mutex.rs
+++ b/src/thread_local/mutex.rs
@@ -237,7 +237,8 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     /// a [`Some`] value with the mutex guard is given instead. The lock will be
     /// unlocked when the guard is dropped.
     ///
-    /// This function does not block.
+    /// This function does not block, and also does not check if the thread local
+    /// node is already in use.
     ///
     /// # Safety
     ///
@@ -385,7 +386,8 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     /// executed against the mutex guard. Once the guard goes out of scope, it
     /// will unlock the mutex.
     ///
-    /// This function will block if the lock is unavailable.
+    /// This function will block if the lock is unavailable, and also does not
+    /// check if the thread local node is already in use.
     ///
     /// # Safety
     ///

--- a/src/thread_local/mutex.rs
+++ b/src/thread_local/mutex.rs
@@ -1,9 +1,13 @@
-use core::cell::RefCell;
-use core::fmt;
+use core::cell::{RefCell, RefMut};
+use core::fmt::{self, Debug, Display};
 use core::marker::PhantomData;
+use core::panic::Location;
 
 use crate::raw::{Mutex as RawMutex, MutexGuard as RawMutexGuard, MutexNode};
 use crate::relax::Relax;
+
+#[cfg(test)]
+use crate::test::{LockNew, LockWith};
 
 // A thread_local key holding a [`MutexNode`] instance behind a [`RefCell`].
 //
@@ -31,8 +35,15 @@ loom::thread_local! {
 /// The panic message as a string literal.
 macro_rules! literal_panic_msg {
     () => {
-        "At most one thread_local MCS lock can be held at any time within a thread"
+        "a thread local MCS lock is already held by this thread"
     };
+}
+
+/// Panics the thread with a message pointing to the panic location.
+#[inline(never)]
+#[cold]
+fn panic_already_held(caller: &Location<'static>) -> ! {
+    panic!("{}, conflict at: {}", literal_panic_msg!(), caller)
 }
 
 /// A mutual exclusion primitive useful for protecting shared data.
@@ -211,11 +222,21 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     /// });
     /// ```
     #[inline]
+    #[track_caller]
     pub fn try_lock_with<F, Ret>(&self, f: F) -> Ret
     where
         F: FnOnce(Option<MutexGuard<'_, T, R>>) -> Ret,
     {
-        self.node_with(|raw, node| f(raw.try_lock(node).map(MutexGuard::new)))
+        self.with_borrow_mut(|raw, node| f(MutexGuard::try_new(raw, node)))
+    }
+
+    /// Attempts to acquire this lock and run the closure against its guard.
+    #[inline]
+    pub unsafe fn try_lock_with_unchecked<F, Ret>(&self, f: F) -> Ret
+    where
+        F: FnOnce(Option<MutexGuard<'_, T, R>>) -> Ret,
+    {
+        self.with_borrow_mut_unchecked(|raw, node| f(MutexGuard::try_new(raw, node)))
     }
 
     /// Acquires a mutex, blocking the current thread until it is able to do so.
@@ -282,11 +303,21 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
     /// });
     /// ```
     #[inline]
+    #[track_caller]
     pub fn lock_with<F, Ret>(&self, f: F) -> Ret
     where
         F: FnOnce(MutexGuard<'_, T, R>) -> Ret,
     {
-        self.node_with(|raw, node| f(MutexGuard::new(raw.lock(node))))
+        self.with_borrow_mut(|raw, node| f(MutexGuard::new(raw, node)))
+    }
+
+    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    #[inline]
+    pub unsafe fn lock_with_unchecked<F, Ret>(&self, f: F) -> Ret
+    where
+        F: FnOnce(MutexGuard<'_, T, R>) -> Ret,
+    {
+        self.with_borrow_mut_unchecked(|raw, node| f(MutexGuard::new(raw, node)))
     }
 }
 
@@ -339,29 +370,37 @@ impl<T: ?Sized, R> Mutex<T, R> {
         self.0.get_mut()
     }
 
-    /// Runs `f` over the inner mutex and the thread local node.
+    /// Runs `f` over a raw mutex and thread local node as arguments.
     ///
     /// # Panics
     ///
-    /// Will panic if the thread local [`MutexNode`] is already in use by a held
-    /// lock from this thread.
-    fn node_with<F, Ret>(&self, f: F) -> Ret
+    /// Will panic if the thread local [`MutexNode`] is already in use by a
+    /// lock guard from the same thread.
+    #[track_caller]
+    fn with_borrow_mut<F, Ret>(&self, f: F) -> Ret
     where
         F: FnOnce(&RawMutex<T, R>, &mut MutexNode) -> Ret,
     {
-        #[allow(clippy::option_if_let_else)]
-        NODE.with(|node| match node.try_borrow_mut() {
-            Ok(mut node) => f(&self.0, &mut node),
-            Err(_) => Self::panic_already_held(),
-        })
+        let caller = Location::caller();
+        let panic = |_| panic_already_held(caller);
+        let f = |mut node: RefMut<_>| f(&self.0, &mut node);
+        NODE.with(|node| node.try_borrow_mut().map_or_else(panic, f))
     }
 
-    /// Panics the thread with an appropiate message.
-    #[inline(never)]
-    #[track_caller]
-    #[cold]
-    fn panic_already_held() -> ! {
-        panic!("{}", literal_panic_msg!())
+    /// Runs 'f' over the a raw mutex and thread local node as arguments without
+    /// checking if the node is currently mutably borrowed.
+    ///
+    /// # Safety
+    ///
+    /// Mutably borrowing a [`RefCell`] while references are still live is
+    /// undefined behaviour. This means that two or more guards can not be in
+    /// scope within a single thread at the same time.
+    unsafe fn with_borrow_mut_unchecked<F, Ret>(&self, f: F) -> Ret
+    where
+        F: FnOnce(&RawMutex<T, R>, &mut MutexNode) -> Ret,
+    {
+        // SAFETY: Caller guaranteed that no other references are live.
+        NODE.with(|node| f(&self.0, unsafe { &mut *node.as_ptr() }))
     }
 }
 
@@ -393,7 +432,7 @@ impl<T: ?Sized + fmt::Debug, R: Relax> fmt::Debug for Mutex<T, R> {
 }
 
 #[cfg(test)]
-impl<T: ?Sized, R> crate::test::LockNew for Mutex<T, R> {
+impl<T: ?Sized, R> LockNew for Mutex<T, R> {
     type Target = T;
 
     fn new(value: Self::Target) -> Self
@@ -405,7 +444,7 @@ impl<T: ?Sized, R> crate::test::LockNew for Mutex<T, R> {
 }
 
 #[cfg(test)]
-impl<T: ?Sized, R: Relax> crate::test::LockWith for Mutex<T, R> {
+impl<T: ?Sized, R: Relax> LockWith for Mutex<T, R> {
     type Guard<'a> = MutexGuard<'a, Self::Target, R>
     where
         Self: 'a,
@@ -444,6 +483,59 @@ impl<T: ?Sized, R> crate::test::LockData for Mutex<T, R> {
     }
 }
 
+/// A type that calls the unchecked versions of `lock_with` and `try_lock_with`
+/// when implementing the `LockWith` trait.
+#[cfg(test)]
+struct MutexUnchecked<T: ?Sized, R>(Mutex<T, R>);
+
+#[cfg(test)]
+impl<T: ?Sized, R> LockNew for MutexUnchecked<T, R> {
+    type Target = T;
+
+    fn new(value: Self::Target) -> Self
+    where
+        Self::Target: Sized,
+    {
+        Self(Mutex::new(value))
+    }
+}
+
+/// Implements the test locking interface to verify the unchecked APIs:
+/// `lock_with_unchecked` and `try_lock_with_unchecked`.
+///
+/// # Safety
+///
+/// Callers must guarantee that no more than ONE mutex guard is alive at any
+/// time within a single thread. When falling to do so under Miri testing, Miri
+/// MIGHT flag the test as invoking UB, which is nice. Loom modeling does not
+/// necessarily catch such problems, although those can inadvertently break the
+/// memory model invariants which will then fire Loom errors.
+#[cfg(test)]
+impl<T: ?Sized, R: Relax> LockWith for MutexUnchecked<T, R> {
+    type Guard<'a> = MutexGuard<'a, Self::Target, R>
+    where
+        Self: 'a,
+        Self::Target: 'a;
+
+    fn try_lock_with<F, Ret>(&self, f: F) -> Ret
+    where
+        F: FnOnce(Option<MutexGuard<'_, T, R>>) -> Ret,
+    {
+        unsafe { self.0.try_lock_with_unchecked(f) }
+    }
+
+    fn lock_with<F, Ret>(&self, f: F) -> Ret
+    where
+        F: FnOnce(MutexGuard<'_, T, R>) -> Ret,
+    {
+        unsafe { self.0.lock_with_unchecked(f) }
+    }
+
+    fn is_locked(&self) -> bool {
+        self.0.is_locked()
+    }
+}
+
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is
 /// dropped (falls out of scope), the lock will be unlocked.
 ///
@@ -468,18 +560,29 @@ pub struct MutexGuard<'a, T: ?Sized, R: Relax> {
 unsafe impl<'a, T: ?Sized + Sync, R: Relax> Sync for MutexGuard<'a, T, R> {}
 
 impl<'a, T: ?Sized, R: Relax> MutexGuard<'a, T, R> {
-    fn new(inner: RawMutexGuard<'a, T, R>) -> Self {
+    /// Creates a new guard instance from a raw guard.
+    fn raw(inner: RawMutexGuard<'a, T, R>) -> Self {
         Self { inner, marker: PhantomData }
+    }
+
+    /// Creates a new guard instance only if the mutex is not already locked.
+    fn try_new(mutex: &'a RawMutex<T, R>, node: &'a mut MutexNode) -> Option<Self> {
+        mutex.try_lock(node).map(Self::raw)
+    }
+
+    /// Creates a new guard instance by locking a raw mutex.
+    fn new(mutex: &'a RawMutex<T, R>, node: &'a mut MutexNode) -> Self {
+        Self::raw(mutex.lock(node))
     }
 }
 
-impl<'a, T: ?Sized + fmt::Debug, R: Relax> fmt::Debug for MutexGuard<'a, T, R> {
+impl<'a, T: ?Sized + Debug, R: Relax> Debug for MutexGuard<'a, T, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
 
-impl<'a, T: ?Sized + fmt::Display, R: Relax> fmt::Display for MutexGuard<'a, T, R> {
+impl<'a, T: ?Sized + Display, R: Relax> Display for MutexGuard<'a, T, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
@@ -519,19 +622,32 @@ unsafe impl<T: ?Sized, R: Relax> crate::loom::Guard for MutexGuard<'_, T, R> {
 
 #[cfg(all(not(loom), test))]
 mod test {
+    use super::MutexUnchecked as InnerUnchecked;
+
+    use crate::relax::Yield;
     use crate::test::tests;
     use crate::thread_local::yields::Mutex;
 
+    type MutexUnchecked<T> = InnerUnchecked<T, Yield>;
+
     #[test]
     fn lots_and_lots() {
-        use std::sync::Arc;
-        let data = Arc::new(Mutex::new(0));
-        tests::lots_and_lots(&data);
+        tests::lots_and_lots::<Mutex<_>>();
+    }
+
+    #[test]
+    fn lots_and_lots_unchecked() {
+        tests::lots_and_lots::<MutexUnchecked<_>>();
     }
 
     #[test]
     fn smoke() {
         tests::smoke::<Mutex<_>>();
+    }
+
+    #[test]
+    fn smoke_unchecked() {
+        tests::smoke::<MutexUnchecked<_>>();
     }
 
     #[test]
@@ -557,6 +673,11 @@ mod test {
     #[test]
     fn test_try_lock() {
         tests::test_try_lock::<Mutex<_>>();
+    }
+
+    #[test]
+    fn test_try_lock_unchecked() {
+        tests::test_try_lock::<MutexUnchecked<_>>();
     }
 
     #[test]
@@ -592,19 +713,39 @@ mod test {
     }
 
     #[test]
+    fn test_lock_arc_access_in_unwind_uncheckd() {
+        tests::test_lock_arc_access_in_unwind::<MutexUnchecked<_>>();
+    }
+
+    #[test]
     fn test_lock_unsized() {
         tests::test_lock_unsized::<Mutex<_>>();
+    }
+
+    #[test]
+    fn test_lock_unsized_unchecked() {
+        tests::test_lock_unsized::<MutexUnchecked<_>>();
     }
 }
 
 #[cfg(all(loom, test))]
 mod model {
+    use super::MutexUnchecked as InnerUnchecked;
+
     use crate::loom::models;
+    use crate::relax::Yield;
     use crate::thread_local::yields::Mutex;
+
+    type MutexUnchecked<T> = InnerUnchecked<T, Yield>;
 
     #[test]
     fn try_lock_join() {
         models::try_lock_join::<Mutex<_>>();
+    }
+
+    #[test]
+    fn try_lock_join_unchecked() {
+        models::try_lock_join::<MutexUnchecked<_>>();
     }
 
     #[test]
@@ -613,7 +754,17 @@ mod model {
     }
 
     #[test]
+    fn lock_join_unchecked() {
+        models::lock_join::<MutexUnchecked<_>>();
+    }
+
+    #[test]
     fn mixed_lock_join() {
         models::mixed_lock_join::<Mutex<_>>();
+    }
+
+    #[test]
+    fn mixed_lock_join_unchecked() {
+        models::mixed_lock_join::<MutexUnchecked<_>>();
     }
 }


### PR DESCRIPTION
Add two new locking APIs for `thread_local::Mutex`:

- `try_lock_with_unchecked`
- `lock_with_unchecked`

Both APIs are unsafe, but are more efficient, specially at hot paths, as they opt-out the runtime borrow checking. Users must guarantee that no more than one `thread_local::MutexGuard` are alive within a single thread at any time.

Add caller location for `try_lock_with` and `lock_with` APIs for better debugging experience when panicking.