### PR TITLE
Add Default impl for MutexNode

### DIFF
--- a/src/raw/mutex.rs
+++ b/src/raw/mutex.rs
@@ -663,6 +663,21 @@ mod test {
     use crate::test::tests;
 
     #[test]
+    fn node_default_and_new_init() {
+        use super::MutexNode;
+
+        let mut d = MutexNode::default();
+        let dinit = d.initialize();
+        assert!(dinit.next.get_mut().is_null());
+        assert!(*dinit.locked.get_mut());
+
+        let mut n = MutexNode::new();
+        let ninit = n.initialize();
+        assert!(ninit.next.get_mut().is_null());
+        assert!(*ninit.locked.get_mut());
+    }
+
+    #[test]
     fn lots_and_lots() {
         tests::lots_and_lots::<Mutex<_>>();
     }

--- a/src/raw/mutex.rs
+++ b/src/raw/mutex.rs
@@ -79,6 +79,12 @@ impl MutexNode {
     }
 }
 
+impl Default for MutexNode {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A mutual exclusion primitive useful for protecting shared data.
 ///
 /// This mutex will block threads waiting for the lock to become available. The

--- a/src/thread_local/mutex.rs
+++ b/src/thread_local/mutex.rs
@@ -762,13 +762,11 @@ unsafe impl<T: ?Sized, R: Relax> crate::loom::Guard for MutexGuard<'_, T, R> {
 
 #[cfg(all(not(loom), test))]
 mod test {
-    use super::MutexUnchecked as InnerUnchecked;
-
     use crate::relax::Yield;
     use crate::test::tests;
     use crate::thread_local::yields::Mutex;
 
-    type MutexUnchecked<T> = InnerUnchecked<T, Yield>;
+    type MutexUnchecked<T> = super::MutexUnchecked<T, Yield>;
 
     #[test]
     fn lots_and_lots() {


### PR DESCRIPTION
`Default` trait implementation simply calls `Self::new()`.