### PR TITLE
refactor(api)!: remove MutexNode reexports

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -34,6 +34,12 @@ command = "cargo"
 env = { "RUSTFLAGS" = "${CLIPPY_FLAGS}" }
 args = ["hack", "clippy", "--feature-powerset", "--no-dev-deps"]
 
+# Run example.
+[tasks.example]
+command = "cargo"
+env = { "RUSTFLAGS" = "${CLIPPY_FLAGS}" }
+args = ["run", "--example", "${@}", "--all-features"]
+
 # Lint all feature combinations with carg-hack on test profile.
 [tasks.lint-test]
 command = "cargo"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ more information.
 use std::sync::Arc;
 use std::thread;
 
-use mcslock::raw::spins::{Mutex, MutexNode};
+use mcslock::raw::{spins::Mutex, MutexNode};
 
 fn main() {
     let mutex = Arc::new(Mutex::new(0));

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -2,7 +2,7 @@ use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
 
-use mcslock::raw::spins::{Mutex, MutexNode};
+use mcslock::raw::{spins::Mutex, MutexNode};
 
 fn main() {
     const N: usize = 10;

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -41,10 +41,10 @@ fn main() {
                     tx.send(()).unwrap();
                 }
                 // the lock is unlocked here when `data` goes out of scope.
-            })
+            });
         });
     }
-    let _message = rx.recv().unwrap();
+    let _message = rx.recv();
 
     let count = data.lock_with_local(&NODE, |guard| *guard);
     assert_eq!(count, N);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! use std::sync::Arc;
 //! use std::thread;
 //!
-//! use mcslock::raw::spins::{Mutex, MutexNode};
+//! use mcslock::raw::{spins::Mutex, MutexNode};
 //!
 //! let mutex = Arc::new(Mutex::new(0));
 //! let c_mutex = Arc::clone(&mutex);

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -40,14 +40,12 @@ pub mod spins {
     use super::mutex;
     use crate::relax::Spin;
 
-    pub use mutex::MutexNode;
-
     /// A `raw` MCS lock that implements the [`Spin`] relax strategy.
     ///
     /// # Example
     ///
     /// ```
-    /// use mcslock::raw::spins::{Mutex, MutexNode};
+    /// use mcslock::raw::{spins::Mutex, MutexNode};
     ///
     /// let mutex = Mutex::new(0);
     /// let mut node = MutexNode::new();
@@ -66,14 +64,12 @@ pub mod spins {
         use super::mutex;
         use crate::relax::SpinBackoff;
 
-        pub use mutex::MutexNode;
-
         /// A `raw` MCS lock that implements the [`SpinBackoff`] relax strategy.
         ///
         /// # Example
         ///
         /// ```
-        /// use mcslock::raw::spins::backoff::{Mutex, MutexNode};
+        /// use mcslock::raw::{spins::backoff::Mutex, MutexNode};
         ///
         /// let mutex = Mutex::new(0);
         /// let mut node = MutexNode::new();
@@ -95,14 +91,12 @@ pub mod yields {
     use super::mutex;
     use crate::relax::Yield;
 
-    pub use mutex::MutexNode;
-
     /// A `raw` MCS lock that implements the [`Yield`] relax strategy.
     ///
     /// # Example
     ///
     /// ```
-    /// use mcslock::raw::yields::{Mutex, MutexNode};
+    /// use mcslock::raw::{yields::Mutex, MutexNode};
     ///
     /// let mutex = Mutex::new(0);
     /// let mut node = MutexNode::new();
@@ -122,14 +116,12 @@ pub mod yields {
         use super::mutex;
         use crate::relax::YieldBackoff;
 
-        pub use mutex::MutexNode;
-
         /// A `raw` MCS lock that implements the [`YieldBackoff`] relax strategy.
         ///
         /// # Example
         ///
         /// ```
-        /// use mcslock::raw::yields::backoff::{Mutex, MutexNode};
+        /// use mcslock::raw::{yields::backoff::Mutex, MutexNode};
         ///
         /// let mutex = Mutex::new(0);
         /// let mut node = MutexNode::new();
@@ -149,14 +141,12 @@ pub mod loops {
     use super::mutex;
     use crate::relax::Loop;
 
-    pub use mutex::MutexNode;
-
     /// A `raw` MCS lock that implements the [`Loop`] relax strategy.
     ///
     /// # Example
     ///
     /// ```
-    /// use mcslock::raw::loops::{Mutex, MutexNode};
+    /// use mcslock::raw::{loops::Mutex, MutexNode};
     ///
     /// let mutex = Mutex::new(0);
     /// let mut node = MutexNode::new();


### PR DESCRIPTION
This PR removes all `MutexNode` reexports, since they do not particularly make import statements any shorter than using the canonical path, and because users may understand  them as if they were different from each other, which is not the case.

Breaking changes:
- Removed `raw::spins::MutexNode`.
- Removed `raw::yields::MutexNode`.
- Removed `raw::loops::MutexNode`.
- Removed `raw::spins::backoff::MutexNode`.
- Removed `raw::yields::backoff::MutexNode`.

Canonical path has not changed: `raw::MutexNode`.