### PR TITLE
refact!: require unsafe for Relax

### DIFF
--- a/src/barging/mutex.rs
+++ b/src/barging/mutex.rs
@@ -161,7 +161,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
         let mut node = MutexNode::new();
         let guard = self.raw.lock(&mut node);
         while !self.try_lock_fast() {
-            let mut relax = R::default();
+            let mut relax = R::new();
             while self.locked.load(Relaxed) {
                 relax.relax();
             }

--- a/src/raw/mutex.rs
+++ b/src/raw/mutex.rs
@@ -356,7 +356,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
         if !pred.is_null() {
             // SAFETY: Already verified that predecessor is not null.
             unsafe { &*pred }.next.store(node.as_ptr(), Release);
-            let mut relax = R::default();
+            let mut relax = R::new();
             while node.locked.load(Relaxed) {
                 relax.relax();
             }
@@ -430,7 +430,7 @@ impl<T: ?Sized, R: Relax> Mutex<T, R> {
             let false = self.try_unlock(node.as_ptr()) else { return };
             // But if we are not the tail, then we have a pending successor. We
             // must wait for them to finish linking with us.
-            let mut relax = R::default();
+            let mut relax = R::new();
             loop {
                 next = node.next.load(Relaxed);
                 let true = next.is_null() else { break };


### PR DESCRIPTION
Breaking changes:
- `mcslock::relax::Relax` is now properly marked as a unsafe trait. There is a safety invariant that implementers must satisfy that was previously overlooked and undocumented. `Relax` functions must not exit the thread, doing so is undefined behavior.
-  `mcslock::relax::Relax` no longer requires that types must also implement `Default`.
- `mcslock::relax::Relax` now requires implementing the `new` function, which is now used to create the initial value. Previously the value that was created by a type's `Default::default` implementation.
- All relax types under `mcslock::relax::*` no longer implement `Default`.