### PR TITLE
refact!: move lock_api under barging

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ use std::sync::Arc;
 use std::thread;
 
 // Requires `barging` feature.
-use mcslock::barging::spins::Mutex;
+use mcslock::barging::spins::backoff::Mutex;
 
 fn main() {
     let mutex = Arc::new(Mutex::new(0));
@@ -251,7 +251,7 @@ each of your dependencies, including this one.
 [`barging::Mutex`]: https://docs.rs/mcslock/latest/mcslock/barging/struct.Mutex.html
 [`raw`]: https://docs.rs/mcslock/latest/mcslock/raw/index.html
 [`barging`]: https://docs.rs/mcslock/latest/mcslock/barging/index.html
-[`lock_api`]: https://docs.rs/mcslock/latest/mcslock/lock_api/index.html
+[`lock_api`]: https://docs.rs/mcslock/latest/mcslock/barging/lock_api/index.html
 [`thread_local_node!`]: https://docs.rs/mcslock/latest/mcslock/macro.thread_local_node.html
 [`std::sync::Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
 [`parking_lot::Mutex`]: https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html

--- a/examples/lock_api.rs
+++ b/examples/lock_api.rs
@@ -9,8 +9,8 @@ use std::thread;
 // their code.
 //
 // Maybe spin::lock_api::{Mutex, MutexGuard} is better for your use case? Switch it!
-pub type Mutex<T> = mcslock::lock_api::spins::Mutex<T>;
-pub type MutexGuard<'a, T> = mcslock::lock_api::spins::MutexGuard<'a, T>;
+pub type Mutex<T> = mcslock::barging::lock_api::spins::Mutex<T>;
+pub type MutexGuard<'a, T> = mcslock::barging::lock_api::spins::MutexGuard<'a, T>;
 
 fn main() {
     const N: usize = 10;

--- a/src/barging/lock_api/mod.rs
+++ b/src/barging/lock_api/mod.rs
@@ -5,11 +5,9 @@
 //! [`barging::Mutex`] type will implement the [`lock_api::RawMutex`] trait when
 //! this feature is enabled.
 //!
-//! The Mutex is generic over the relax strategy. User may choose a strategy
-//! as long as it implements the [`Relax`] trait. There is a number of strategies
-//! provided by the [`relax`] module. The following modules provide type aliases
-//! for [`lock_api::Mutex`] and [`lock_api::MutexGuard`] associated with one
-//! relax strategy. See their documentation for more information.
+//! The following modules provide type aliases for [`lock_api::Mutex`] and
+//! [`lock_api::MutexGuard`] that are associated with a relax strategy. See
+//! their documentation for more information.
 //!
 //! [`relax`]: crate::relax
 //! [`Relax`]: crate::relax::Relax
@@ -35,7 +33,7 @@ pub mod spins {
     /// # Example
     ///
     /// ```
-    /// use mcslock::lock_api::spins::Mutex;
+    /// use mcslock::barging::lock_api::spins::Mutex;
     ///
     /// let mutex = Mutex::new(0);
     /// let guard = mutex.lock();
@@ -60,7 +58,7 @@ pub mod spins {
         /// # Example
         ///
         /// ```
-        /// use mcslock::lock_api::spins::backoff::Mutex;
+        /// use mcslock::barging::lock_api::spins::backoff::Mutex;
         ///
         /// let mutex = Mutex::new(0);
         /// let guard = mutex.lock();
@@ -88,7 +86,7 @@ pub mod yields {
     /// # Example
     ///
     /// ```
-    /// use mcslock::lock_api::yields::Mutex;
+    /// use mcslock::barging::lock_api::yields::Mutex;
     ///
     /// let mutex = Mutex::new(0);
     /// let guard = mutex.lock();
@@ -114,7 +112,7 @@ pub mod yields {
         /// # Example
         ///
         /// ```
-        /// use mcslock::lock_api::yields::backoff::Mutex;
+        /// use mcslock::barging::lock_api::yields::backoff::Mutex;
         ///
         /// let mutex = Mutex::new(0);
         /// let guard = mutex.lock();
@@ -140,7 +138,7 @@ pub mod loops {
     /// # Example
     ///
     /// ```
-    /// use mcslock::lock_api::loops::Mutex;
+    /// use mcslock::barging::lock_api::loops::Mutex;
     ///
     /// let mutex = Mutex::new(0);
     /// let guard = mutex.lock();

--- a/src/barging/lock_api/mutex.rs
+++ b/src/barging/lock_api/mutex.rs
@@ -67,7 +67,7 @@ impl<T: ?Sized, Rs: Relax, Rq: Relax> LockData for Mutex<T, Rs, Rq> {
 
 #[cfg(test)]
 mod test {
-    use crate::lock_api::yields::Mutex;
+    use crate::barging::lock_api::yields::Mutex;
     use crate::test::tests;
 
     #[test]

--- a/src/barging/mod.rs
+++ b/src/barging/mod.rs
@@ -35,6 +35,10 @@
 mod mutex;
 pub use mutex::{Mutex, MutexGuard};
 
+#[cfg(all(feature = "lock_api", not(loom)))]
+#[cfg_attr(docsrs, doc(cfg(feature = "lock_api")))]
+pub mod lock_api;
+
 /// A `barging` MCS lock alias that signals the processor that it is running
 /// a busy-wait spin-loop during lock contention.
 pub mod spins {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,8 @@
 //! the front of the waiting queue thread, which means this it is an unfair lock.
 //! This implementation can be enabled through the `barging` feature, it is
 //! suitable for `no_std` environments, and the locking APIs are compatible with
-//! the `lock_api` crate. See [`mod@barging`] and [`mod@lock_api`] modules for
-//! more information.
+//! the `lock_api` crate. See [`mod@barging`] and [`lock_api`] modules for more
+//! information.
 //!
 //! ```
 //! # #[cfg(feature = "barging")]
@@ -112,7 +112,7 @@
 //! use std::sync::Arc;
 //! use std::thread;
 //!
-//! use mcslock::barging::spins::Mutex;
+//! use mcslock::barging::spins::backoff::Mutex;
 //!
 //! let mutex = Arc::new(Mutex::new(0));
 //! let c_mutex = Arc::clone(&mutex);
@@ -163,7 +163,7 @@
 //!
 //! This feature implements the [`RawMutex`] trait from the [lock_api]
 //! crate for [`barging::Mutex`]. Aliases are provided by the
-//! [`mod@lock_api`] module. This feature is `no_std` compatible.
+//! [`lock_api`] module. This feature is `no_std` compatible.
 //!
 //! ## Related projects
 //!
@@ -177,6 +177,7 @@
 //! [`MutexNode`]: raw::MutexNode
 //! [`LocalMutexNode`]: raw::LocalMutexNode
 //! [`thread_local_node!`]: crate::thread_local_node
+//! [`lock_api`]: barging::lock_api
 //! [`std::sync::Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
 //! [`parking_lot::Mutex`]: https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html
 //! [`RawMutex`]: https://docs.rs/lock_api/latest/lock_api/trait.RawMutex.html
@@ -208,10 +209,6 @@ pub mod relax;
 #[cfg(feature = "barging")]
 #[cfg_attr(docsrs, doc(cfg(feature = "barging")))]
 pub mod barging;
-
-#[cfg(all(feature = "lock_api", feature = "barging", not(loom)))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "lock_api", feature = "barging"))))]
-pub mod lock_api;
 
 #[cfg(feature = "thread_local")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread_local")))]


### PR DESCRIPTION
Breaking changes:
- Move root level `lock_api` module under the `barging` module. The aliases' inner types have not changed, that is, they are still the `barging::Mutex` and `barging::MutexGuard` types. Moving the module under `barging` reinforces that those aliases refer to a context-free, not FIFO guaranteed MCS lock implementation.